### PR TITLE
feat: Attempt to explain why a given wheel is incompatible

### DIFF
--- a/news/10793.feature.rst
+++ b/news/10793.feature.rst
@@ -1,0 +1,2 @@
+When a "wheel is incompatible with this platform" error is shown, attempt to provide a
+specific reason why.

--- a/src/pip/_internal/exceptions/__init__.py
+++ b/src/pip/_internal/exceptions/__init__.py
@@ -68,6 +68,7 @@ from pip._internal.exceptions.uninstall import (
     UninstallMissingRecord,
 )
 from pip._internal.exceptions.wheel import (
+    IncompatibleWheelError,
     InvalidWheel,
     InvalidWheelFilename,
     UnsupportedWheel,
@@ -113,6 +114,7 @@ __all__ = [
     "LegacyDistutilsInstall",
     "UninstallMissingRecord",
     # wheel
+    "IncompatibleWheelError",
     "InvalidWheel",
     "InvalidWheelFilename",
     "UnsupportedWheel",

--- a/src/pip/_internal/exceptions/wheel.py
+++ b/src/pip/_internal/exceptions/wheel.py
@@ -1,6 +1,20 @@
 """Wheel-related pip exceptions."""
 
-from pip._internal.exceptions._base import InstallationError
+from __future__ import annotations
+
+import operator
+import platform
+import re
+import sys
+import sysconfig
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+from pip._vendor.packaging.tags import INTERPRETER_SHORT_NAMES, Tag
+from pip._vendor.packaging.utils import parse_wheel_filename
+from pip._vendor.rich.text import Text
+
+from pip._internal.exceptions._base import DiagnosticPipError, InstallationError
 
 
 class InvalidWheelFilename(InstallationError):
@@ -20,3 +34,264 @@ class InvalidWheel(InstallationError):
 
     def __str__(self) -> str:
         return f"Wheel '{self.name}' located at {self.location} is invalid."
+
+
+def _re_parse(pattern: str, text: str) -> tuple[str, ...] | None:
+    if match := re.match(pattern, text):
+        return match.groups()
+    return None
+
+
+def _explain_python_tag(full_tag: Tag) -> str | None:
+    """Try to explain Python incompatibilities, if possible.
+
+    Specifically checks Python implementation and version."""
+    groups = _re_parse(r"([a-z]+)(\d[\d_]*)", full_tag.interpreter)
+    if not groups:
+        return None
+    impl, version = groups
+
+    # Expand abbreviated implementation name if needed.
+    for fullname, abbrev in INTERPRETER_SHORT_NAMES.items():
+        if impl == abbrev:
+            impl = fullname
+            break
+
+    if impl != "python" and impl.lower() != sys.implementation.name.lower():
+        return (
+            f"Wheel requires a different Python implementation: {impl}"
+            f" (current: {sys.implementation.name})"
+        )
+
+    # If wheel targets stable or no ABI, then Python version is just a minimum.
+    if full_tag.abi in ("abi3", "abi3t", "none"):
+        op = operator.gt
+        plus = "+"
+    else:
+        op = operator.ne
+        plus = ""
+
+    if impl not in ("python", "cpython"):
+        return None
+
+    # Check Python language version.
+    sys_major, sys_minor = sys.version_info.major, sys.version_info.minor
+    if len(version) == 1 and op(int(version), sys_major):
+        return f"Wheel requires Python {version}{plus} (current: {sys_major})"
+    elif len(version) > 1:
+        version_tuple = (int(version[0]), int(version[1:]))
+        if op(version_tuple, sys.version_info[:2]):
+            return (
+                f"Wheel requires Python {version[0]}.{version[1:]}{plus}"
+                f" (current: {sys_major}.{sys_minor})"
+            )
+
+    return None
+
+
+def _explain_abi_tag(tag: str) -> str | None:
+    """Try to explain ABI incompatibilities, if possible.
+
+    Specific checks only include free-threading/no free-threading.
+    """
+    if tag.startswith("cp") and sys.version_info >= (3, 13):
+        gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED") or 0
+        wheel_free_threading = tag.endswith("t")
+        if gil_disabled and not wheel_free_threading:
+            return "Wheel only supports non free-threaded Python"
+        elif not gil_disabled and wheel_free_threading:
+            return "Wheel only supports free-threaded Python"
+
+    return None
+
+
+@dataclass(frozen=True)
+class WindowsTag:
+    system: str = field(init=False, default="Windows")
+    architecture: str
+
+
+@dataclass(frozen=True)
+class MacOSTag:
+    system: str = field(init=False, default="macOS")
+    architecture: str
+    release: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class LinuxTag:
+    system: str = field(init=False, default="Linux")
+    libc: Literal["glibc", "musl"]
+    libc_version: tuple[int, int]
+    architecture: str
+
+
+@dataclass(frozen=True)
+class AndroidTag:
+    system: Final = "Android"
+    architecture: Final = "#not-implemented"
+
+
+@dataclass(frozen=True)
+class iOSTag:
+    system: Final = "iOS"
+    architecture: Final = "#not-implemented"
+
+
+def _parse_platform_tag(
+    tag: str,
+) -> WindowsTag | MacOSTag | LinuxTag | AndroidTag | iOSTag | None:
+    tag = tag.lower()
+    if tag.startswith("win_"):
+        return WindowsTag(tag.removeprefix("win_"))
+
+    if groups := _re_parse(r"macosx_(\d+)_(\d+)_(.+)", tag):
+        major, minor, arch = groups
+        return MacOSTag(arch, (int(major), int(minor)))
+
+    if match := re.match(r"manylinux(1|2010|2014)_(.+)", tag):
+        glibc_ver, arch = match.groups()
+        legacy_mapping = {"1": (2, 5), "2010": (2, 12), "2014": (2, 17)}
+        return LinuxTag("glibc", legacy_mapping[glibc_ver], arch)
+    if groups := _re_parse(r"manylinux_(\d+)_(\d+)_(.+)", tag):
+        major, minor, arch = groups
+        return LinuxTag("glibc", (int(major), int(minor)), arch)
+    if groups := _re_parse(r"musllinux_(\d+)_(\d+)_(.+)", tag):
+        major, minor, arch = groups
+        return LinuxTag("musl", (int(major), int(minor)), arch)
+
+    if tag.startswith("ios"):
+        return iOSTag()
+    if tag.startswith("android"):
+        return AndroidTag()
+
+    return None
+
+
+def _explain_platform_tag(raw_tag: str, supported_tags: frozenset[str]) -> str | None:
+    """Try to explain platform incompatibilities, if possible.
+
+    Specific checks currently include OS, architecture, and libc mismatches.
+    """
+    tag = _parse_platform_tag(raw_tag)
+    if tag is None:
+        return None  # This is an unknown platform, give up.
+
+    # Standardize around "macOS" as it's more well-known
+    current_system = "macOS" if platform.system() == "Darwin" else platform.system()
+    if tag.system.lower() != current_system.lower():
+        return f"Wheel requires {tag.system}"
+
+    if isinstance(tag, (AndroidTag, iOSTag)):
+        # TODO: not implemented yet, these platforms are niche.
+        return None
+
+    # HACK: Deduce (most of) what this environment supports by inspecting the
+    # supported tags returned by packaging. This is hacky, but it's more reliable
+    # than trying to determine the OS version, libc version, etc. ourselves.
+    supported_platforms = [_parse_platform_tag(t) for t in supported_tags]
+    supported_archs = {p.architecture for p in supported_platforms if p is not None}
+    if tag.architecture not in supported_archs:
+        msg = f"Wheel architecture is unsupported: {tag.architecture}"
+        if len(supported_archs) == 1:
+            msg += f" (current: {next(iter(supported_archs))})"
+        return msg
+
+    def format_version(version: tuple[int, ...]) -> str:
+        return ".".join(map(str, version))
+
+    if isinstance(tag, WindowsTag):
+        # Due to Windows' excellent backwards compatibility, this should've been an
+        # architecture issue but it wasn't, give up.
+        return None
+    elif isinstance(tag, MacOSTag):
+        current_release = max(
+            p.release for p in supported_platforms if isinstance(p, MacOSTag)
+        )
+        # NOTE: due to the many changes to macOS's versioning scheme, this is imperfect.
+        if current_release < tag.release:
+            return (
+                f"Wheel requires macOS >= {format_version(tag.release)}"
+                f" (current: {format_version(current_release)})"
+            )
+    elif isinstance(tag, LinuxTag):
+        sys_libc, _ = platform.libc_ver()
+        if tag.libc != sys_libc:
+            return f"Wheel requires {tag.libc} (current: {sys_libc})"
+        sys_libc_ver = max(
+            p.libc_version
+            for p in supported_platforms
+            if isinstance(p, LinuxTag) and p.libc == sys_libc
+        )
+        if sys_libc_ver < tag.libc_version:
+            return (
+                f"Wheel requires {tag.libc} {format_version(tag.libc_version)}+"
+                f" (current: {format_version(sys_libc_ver)})"
+            )
+
+    return None
+
+
+def diagnose_incompatible_wheel(
+    filename: str, supported_tags: frozenset[Tag]
+) -> str | None:
+    """Determine reasons why a wheel is incompatible.
+
+    Inspects the wheel's supported tags and applies best-effort heuristics
+    to determine specific reasons, focusing on the prominent sources
+    of incompatibilities that are feasible to verify.
+
+    Returns None if all efforts fail.
+    """
+
+    supported_platforms = frozenset(t.platform for t in supported_tags)
+    supported_abis = frozenset(t.abi for t in supported_tags)
+
+    def diagnose_one(tag: Tag) -> str | None:
+        """Diagnose why one tag is unsuppported.
+
+        Returns the most important reason even if there are multiple
+        incompatibilities, in this order: Platform -> Interpreter -> ABI.
+        """
+        # Confirm that platform/abi is not supported (to avoid false positives).
+        if tag.platform not in supported_platforms:
+            if reason := _explain_platform_tag(tag.platform, supported_platforms):
+                return reason
+            return f"Wheel requires a different platform: {tag.platform}"
+        # The interpreter tag is weird because if the stable ABI is in use, then
+        # python version is only a baseline.
+        if reason := _explain_python_tag(tag):
+            return reason
+        if tag.abi not in supported_abis:
+            if reason := _explain_abi_tag(tag.abi):
+                return reason
+            return f"Wheel ABI is unsupported: {tag.abi}"
+        return None
+
+    _, _, _, tags = parse_wheel_filename(filename)
+    if len(tags) > 1:
+        # This wheel supports multiple tags, first try to surface the reason
+        # common to all tags. If that fails, then just print each tag separately.
+        tag_reasons = {t: diagnose_one(t) for t in tags}
+        unique_reasons = set(tag_reasons.values())
+        if len(unique_reasons) == 1 and unique_reasons != {None}:
+            return unique_reasons.pop()
+
+        return (
+            "None of the wheel's tags match the current environment:\n  "
+            + "\n  ".join(map(str, tags))
+        )
+
+    return diagnose_one(next(iter(tags)))
+
+
+class IncompatibleWheelError(DiagnosticPipError, UnsupportedWheel):
+    reference = "incompatible-wheel"
+
+    def __init__(self, wheel_filename: str, reason: str | None) -> None:
+        hint = "Run 'pip debug -v' for a list of compatible tags for your system."
+        super().__init__(
+            message=Text.assemble((wheel_filename, "cyan"), " is incompatible"),
+            context=Text(reason) if reason else None,
+            hint_stmt=hint,
+        )

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -64,7 +64,18 @@ class TargetPython:
 
         # This is used to cache the return value of get_(un)sorted_tags.
         self._valid_tags: list[Tag] | None = None
-        self._valid_tags_set: set[Tag] | None = None
+        self._valid_tags_set: frozenset[Tag] | None = None
+
+    def is_current_interpreter(self) -> bool:
+        """
+        Does this target Python match the current interpreter?
+        """
+        return not bool(
+            self.abis
+            or self.implementation
+            or self.platforms
+            or (self.py_version_info != sys.version_info[:3])
+        )
 
     def format_given(self) -> str:
         """
@@ -111,12 +122,12 @@ class TargetPython:
 
         return self._valid_tags
 
-    def get_unsorted_tags(self) -> set[Tag]:
+    def get_unsorted_tags(self) -> frozenset[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
 
         This is important for performance.
         """
         if self._valid_tags_set is None:
-            self._valid_tags_set = set(self.get_sorted_tags())
+            self._valid_tags_set = frozenset(self.get_sorted_tags())
 
         return self._valid_tags_set

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -23,6 +23,7 @@ from pip._vendor.rich.markup import escape
 from pip._internal.cache import CacheEntry, WheelCache
 from pip._internal.exceptions import (
     DistributionNotFound,
+    IncompatibleWheelError,
     InstallationError,
     InvalidInstalledPackage,
     MetadataInconsistent,
@@ -30,6 +31,7 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
     UnsupportedWheel,
 )
+from pip._internal.exceptions.wheel import diagnose_incompatible_wheel
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution, get_default_environment
 from pip._internal.models.link import Link
@@ -135,8 +137,14 @@ class Factory:
         if not link.is_wheel:
             return
         wheel = Wheel(link.filename)
-        if wheel.supported(self._finder.target_python.get_unsorted_tags()):
+        supported_tags = self._finder.target_python.get_unsorted_tags()
+        if wheel.supported(supported_tags):
             return
+        if self._finder.target_python.is_current_interpreter():
+            reason = diagnose_incompatible_wheel(wheel.filename, supported_tags)
+            raise IncompatibleWheelError(wheel.filename, reason)
+        # It's not worth the complexity to attempt to deduce an explanation
+        # when we're targeting a different interpreter.
         msg = f"{link.filename} is not a supported wheel on this platform."
         raise UnsupportedWheel(msg)
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -854,10 +854,8 @@ def test_install_unsupported_wheel_file(
         expect_error=True,
         expect_stderr=True,
     )
-    assert (
-        "simple.dist-0.1-py1-none-invalid.whl is not a supported wheel on this platform"
-        in result.stderr
-    )
+    assert "simple.dist-0.1-py1-none-invalid.whl is incompatible" in result.stderr
+    assert "Wheel requires a different platform: invalid" in result.stderr
     assert len(result.files_created) == 0
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1354,6 +1354,14 @@ def need_mercurial(fn: _Test) -> _Test:
     return pytest.mark.mercurial(need_executable("Mercurial", ("hg", "version"))(fn))
 
 
+cpython_only = pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="CPython-only test"
+)
+linux_only = pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
+windows_only = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+macos_only = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only test")
+
+
 class InMemoryPipResult:
     def __init__(self, returncode: int, stdout: str) -> None:
         self.returncode = returncode

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -6,15 +6,33 @@ import io
 import locale
 import logging
 import pathlib
+import platform
 import sys
+import sysconfig
 import textwrap
+from collections.abc import Callable
+from typing import Any, Final
+from unittest.mock import patch
 
 import pytest
 
 from pip._vendor import rich
+from pip._vendor.packaging.tags import Tag
 
 from pip._internal.exceptions import DiagnosticPipError, ExternallyManagedEnvironment
+from pip._internal.exceptions.wheel import (
+    AndroidTag,
+    IncompatibleWheelError,
+    LinuxTag,
+    MacOSTag,
+    WindowsTag,
+    _parse_platform_tag,
+    diagnose_incompatible_wheel,
+    iOSTag,
+)
+from pip._internal.utils.compatibility_tags import get_supported
 
+from tests.lib import cpython_only, linux_only, macos_only
 from tests.lib.output import render_to_text as rendered
 
 
@@ -260,6 +278,26 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             """)
 
 
+def _current_version_tag(*, major_offset: int = 0, minor_offset: int = 0) -> str:
+    major = sys.version_info.major + major_offset
+    minor = sys.version_info.minor + minor_offset
+    return f"{major}{minor}"
+
+
+def _mock_get_config_var(**kwd: object) -> Callable[[str], Any]:
+    """
+    Patch sysconfig.get_config_var for arbitrary keys.
+    """
+    get_config_var = sysconfig.get_config_var
+
+    def _mocked_get_config_var(var: str) -> Any:
+        if var in kwd:
+            return kwd[var]
+        return get_config_var(var)
+
+    return _mocked_get_config_var
+
+
 class TestDiagnosticPipErrorPresentation_Unicode:
     def test_complete(self) -> None:
         err = DiagnosticPipError(
@@ -433,6 +471,257 @@ class TestDiagnosticPipErrorPresentation_Unicode:
 
             × Oh no!
               It broke. :(
+            """)
+
+
+class TestIncompatibleWheelDiagnostic:
+    supported_tags: Final[frozenset[Tag]] = frozenset(get_supported())
+    supported_platforms: Final[frozenset[str]] = frozenset(
+        t.platform for t in get_supported()
+    )
+
+    @pytest.mark.parametrize(
+        "raw_tag, expected",
+        [
+            ("win_amd64", WindowsTag("amd64")),
+            ("macosx_11_0_arm64", MacOSTag("arm64", (11, 0))),
+            ("manylinux_2_28_x86_64", LinuxTag("glibc", (2, 28), "x86_64")),
+            ("manylinux2014_x86_64", LinuxTag("glibc", (2, 17), "x86_64")),
+            ("musllinux_1_2_x86_64", LinuxTag("musl", (1, 2), "x86_64")),
+            ("android_27_arm64_v8a", AndroidTag()),
+            ("ios_13_0_arm64_iphonesimulator", iOSTag()),
+            ("freebsd_13_x86_64", None),
+            ("windows_amd64", None),
+            ("linux_x86_64", None),
+            ("macosx_notreal", None),
+        ],
+    )
+    def test_parse_platform_tag(self, raw_tag: str, expected: object) -> None:
+        assert _parse_platform_tag(raw_tag) == expected
+
+    def test_diagnose_python_major_version(self) -> None:
+        current_major = sys.version_info.major
+        filename = "sample-1.0-py9-none-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires Python 9+ (current: {current_major})"
+        )
+
+    @cpython_only
+    def test_diagnose_cpython_minor_version(self) -> None:
+        future = _current_version_tag(minor_offset=1)
+        filename = f"sample-1.0-cp{future}-cp{future}-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires Python {sys.version_info.major}."
+            f"{sys.version_info.minor + 1} "
+            f"(current: {sys.version_info.major}.{sys.version_info.minor})"
+        )
+
+    @cpython_only
+    @pytest.mark.skipif(
+        sysconfig.get_config_var("Py_GIL_DISABLED") or False, reason="GIL-build only"
+    )
+    def test_diagnose_cpython_abi3_uses_minimum_version(self) -> None:
+        """Test that abi3 wheels use Python version as a minimum."""
+        current = _current_version_tag()
+        future = _current_version_tag(minor_offset=1)
+        filename = f"sample-1.0-cp{future}-abi3-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires Python {sys.version_info.major}."
+            f"{sys.version_info.minor + 1}+ "
+            f"(current: {sys.version_info.major}.{sys.version_info.minor})"
+        )
+
+        filename = f"sample-1.0-cp{current}-abi3-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) is None
+
+    def test_diagnose_python_implementation(self) -> None:
+        if sys.implementation.name.lower() == "pypy":
+            other_implementation = "cp"
+            expected = "cpython"
+        else:
+            other_implementation = "pp"
+            expected = "pypy"
+        filename = f"sample-1.0-{other_implementation}3-none-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires a different Python implementation: {expected}"
+            f" (current: {sys.implementation.name})"
+        )
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="free-threaded Python was only introduced in 3.13",
+    )
+    @cpython_only
+    def test_diagnose_abi_free_threaded_wheel(self) -> None:
+        current = _current_version_tag()
+        filename = f"sample-1.0-cp{current}-cp{current}t-any.whl"
+        supported_tags = frozenset([Tag(f"cp{current}", f"cp{current}", "any")])
+
+        with patch(
+            "pip._internal.exceptions.wheel.sysconfig.get_config_var",
+            _mock_get_config_var(Py_GIL_DISABLED=0),
+        ):
+            assert diagnose_incompatible_wheel(filename, supported_tags) == (
+                "Wheel only supports free-threaded Python"
+            )
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="free-threaded Python was only introduced in 3.13",
+    )
+    @cpython_only
+    def test_diagnose_abi_non_free_threaded_wheel(self) -> None:
+        current = _current_version_tag()
+        filename = f"sample-1.0-cp{current}-cp{current}-any.whl"
+        supported_tags = frozenset([Tag(f"cp{current}", f"cp{current}t", "any")])
+
+        with patch(
+            "pip._internal.exceptions.wheel.sysconfig.get_config_var",
+            _mock_get_config_var(Py_GIL_DISABLED=1),
+        ):
+            assert diagnose_incompatible_wheel(filename, supported_tags) == (
+                "Wheel only supports non free-threaded Python"
+            )
+
+    def test_diagnose_abi_unknown(self) -> None:
+        filename = "sample-1.0-py3-notanabi-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            "Wheel ABI is unsupported: notanabi"
+        )
+
+    def test_diagnose_prioritizes_platform_over_python_and_abi(self) -> None:
+        future_major = sys.version_info.major + 1
+        filename = f"sample-1.0-py{future_major}-notanabi-fakeplat.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            "Wheel requires a different platform: fakeplat"
+        )
+
+    def test_diagnose_prioritizes_python_over_abi(self) -> None:
+        filename = "sample-1.0-py9-notanabi-any.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires Python 9 (current: {sys.version_info.major})"
+        )
+
+    def test_diagnose_platform_different_os(self) -> None:
+        if platform.system() == "Windows":
+            wheel_platform = "manylinux_2_17_x86_64"
+            expected = "Linux"
+        elif platform.system() == "Darwin":
+            wheel_platform = "android_27_arm64_v8a"
+            expected = "Android"
+        else:
+            wheel_platform = "win_amd64"
+            expected = "Windows"
+
+        filename = f"sample-1.0-py3-none-{wheel_platform}.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            f"Wheel requires {expected}"
+        )
+
+    @linux_only
+    def test_diagnose_platform_linux_libc(self) -> None:
+        libc, _ = platform.libc_ver()
+        if libc == "glibc":
+            wheel_platform = "musllinux_1_0_x86_64"
+            expected = "Wheel requires musl (current: glibc)"
+        elif libc == "musl":
+            wheel_platform = "manylinux_1_0_x86_64"
+            expected = "Wheel requires glibc (current: musl)"
+        else:
+            pytest.skip("unsupported Linux libc")
+
+        filename = f"sample-1.0-py3-none-{wheel_platform}.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == expected
+
+    @linux_only
+    def test_diagnose_platform_linux_libc_version(self) -> None:
+        libc, _ = platform.libc_ver()
+        linux_tags = [
+            tag
+            for tag in map(_parse_platform_tag, self.supported_platforms)
+            if isinstance(tag, LinuxTag) and tag.libc == libc
+        ]
+        if not linux_tags:
+            pytest.skip(f"no supported {libc} platform tag")
+
+        prefix = "manylinux" if libc == "glibc" else "musllinux"
+        wheel_platform = f"{prefix}_99_99_{linux_tags[0].architecture}"
+        filename = f"sample-1.0-py3-none-{wheel_platform}.whl"
+
+        reason = diagnose_incompatible_wheel(filename, self.supported_tags)
+        assert reason is not None
+        assert reason.startswith(f"Wheel requires {libc} 99.99+")
+
+    @macos_only
+    def test_diagnose_platform_macos_version(self) -> None:
+        macos_tags = [
+            tag
+            for tag in map(_parse_platform_tag, self.supported_platforms)
+            if isinstance(tag, MacOSTag)
+        ]
+        if not macos_tags:
+            pytest.skip("no supported macOS platform tag")
+
+        wheel_platform = f"macosx_99_99_{macos_tags[0].architecture}"
+        filename = f"sample-1.0-py3-none-{wheel_platform}.whl"
+
+        reason = diagnose_incompatible_wheel(filename, self.supported_tags)
+        assert reason is not None
+        assert reason.startswith("Wheel requires macOS >= 99.99")
+
+    def test_diagnose_platform_same_os_unsupported_architecture(self) -> None:
+        current_system = platform.system()
+        if current_system == "Windows":
+            wheel_platform = "win_notrealarch"
+        elif current_system == "Darwin":
+            wheel_platform = "macosx_10_1_notrealarch"
+        elif current_system == "Linux":
+            libc, _ = platform.libc_ver()
+            prefix = "manylinux" if libc == "glibc" else "musllinux"
+            wheel_platform = f"{prefix}_1_0_notrealarch"
+        else:
+            pytest.skip("unsupported host platform")
+
+        filename = f"sample-1.0-py3-none-{wheel_platform}.whl"
+        reason = diagnose_incompatible_wheel(filename, self.supported_tags)
+        assert reason is not None
+        assert reason.startswith("Wheel architecture is unsupported: notrealarch")
+
+    def test_diagnose_platform_unknown(self) -> None:
+        filename = "sample-1.0-py3-none-fakeplat.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            "Wheel requires a different platform: fakeplat"
+        )
+
+    def test_diagnose_multi_tag_common_reason(self) -> None:
+        """Test that a shared incompatibility reason is reported once."""
+        filename = "sample-1.0-py2.py3-none-fakeplat.whl"
+        assert diagnose_incompatible_wheel(filename, self.supported_tags) == (
+            "Wheel requires a different platform: fakeplat"
+        )
+
+    def test_diagnose_multi_tag_mixed_reasons(self) -> None:
+        """Test that mixed incompatibility reasons fall back to listing wheel tags."""
+        filename = "sample-1.0-py3-none-mysupercomputer.fakeplat.whl"
+        reason = diagnose_incompatible_wheel(filename, self.supported_tags)
+        assert reason is not None
+        assert reason.startswith("None of the wheel's tags match")
+        assert "py3-none-mysupercomputer" in reason
+        assert "py3-none-fakeplat" in reason
+
+    def test_diagnostic_renders_reason_and_hint(self) -> None:
+        current_major = sys.version_info.major
+        future_major = current_major + 1
+        filename = f"sample-1.0-py{future_major}-none-any.whl"
+        reason = diagnose_incompatible_wheel(filename, self.supported_tags)
+        err = IncompatibleWheelError(filename, reason)
+        assert rendered(err) == textwrap.dedent(f"""\
+            error: incompatible-wheel
+
+            × {filename} is incompatible
+            ╰─> Wheel requires Python {future_major}+ (current: {current_major})
+
+            hint: Run 'pip debug -v' for a list of compatible tags for your system.
             """)
 
 

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -120,9 +120,11 @@ class TestTargetPython:
         Test that get_unsorted_tags() uses the cached value.
         """
         target_python = TargetPython(py_version_info=None)
-        target_python._valid_tags_set = {
-            Tag("py2", "none", "any"),
-            Tag("py3", "none", "any"),
-        }
+        target_python._valid_tags_set = frozenset(
+            {
+                Tag("py2", "none", "any"),
+                Tag("py3", "none", "any"),
+            }
+        )
         actual = target_python.get_unsorted_tags()
         assert actual == {Tag("py2", "none", "any"), Tag("py3", "none", "any")}


### PR DESCRIPTION
Add a diagnostic error for incompatible wheels alongside infrastructure that guesses why the wheel is incompatible. The diagnosis is best-effort and is intentionally not comprehensive.

Fixes #10793.

### Example errors

```
$ pip install numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl --dry-run
error: incompatible-wheel

× numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl is incompatible
╰─> Wheel architecture is unsupported: aarch64 (current: x86_64)

hint: Run 'pip debug -v' for a list of compatible tags for your system.
```

```
× numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl is incompatible
╰─> Wheel requires musl (current: glibc)
```

```
× black-25.1.0-pp313-cp313-win_amd64.whl is incompatible
╰─> Wheel requires a different Python implementation: pypy (current: cpython)
```

```
× black-25.1.0-cp313-cp313-win_amd64.whl is incompatible
╰─> Wheel requires Windows
```

```
× cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl is incompatible
╰─> Wheel only supports free-threaded Python
```

```
× cryptography-49.0.0-cp314-cp314-manylinux_2_60_x86_64.whl is incompatible
╰─> Wheel requires glibc 2.60+ (current: 2.43)
```

```
× cryptography-49.0.0-cp315-abi3-manylinux_2_34_x86_64.whl is incompatible
╰─> Wheel requires Python 3.15+ (current: 3.14)
```