### PR TITLE
Fix constraint hash lost for a transitively-needed package given in URL form

### DIFF
--- a/news/14284.bugfix.rst
+++ b/news/14284.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a constraint's hash being ignored for a package that is only needed
+transitively, when the constraint is given in URL form (``name @ url --hash=...``).

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -396,6 +396,15 @@ class Factory:
                 base_identifier = canonicalize_name(parsed_requirement.name)
                 extras = frozenset(parsed_requirement.extras)
 
+        # install_req_from_link_and_ireq() below copies hash_options from
+        # *template*, which for a transitively-needed package is the
+        # requirement that pulled it in, not the constraint -- fall back to
+        # the constraint's own hashes, same as _iter_found_candidates() does.
+        if constraint.hash_options and not template.hash_options:
+            template = copy.copy(template)
+            template.hash_options = {
+                k: list(v) for k, v in constraint.hash_options.items()
+            }
         for link in constraint.links:
             self._fail_if_link_is_unsupported_wheel(link)
             base_candidate = self._make_base_candidate_from_link(

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -301,9 +301,7 @@ def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_succeed(
     never a direct requirement -- the constraint is the only source of a hash
     for it.
     """
-    base_path = create_basic_wheel_for_package(
-        script, "base", "0.1.0", depends=["dep"]
-    )
+    base_path = create_basic_wheel_for_package(script, "base", "0.1.0", depends=["dep"])
     base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
     dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
     dep_hash = hashlib.sha256(dep_path.read_bytes()).hexdigest()
@@ -337,9 +335,7 @@ def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_fail(
     rejected, not silently accepted just because the hash came from a
     constraint rather than a direct requirement.
     """
-    base_path = create_basic_wheel_for_package(
-        script, "base", "0.1.0", depends=["dep"]
-    )
+    base_path = create_basic_wheel_for_package(script, "base", "0.1.0", depends=["dep"])
     base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
     dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
     other_path = create_basic_wheel_for_package(script, "other", "0.1.0")

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -290,6 +290,89 @@ def test_new_resolver_hash_requirement_and_url_constraint_can_fail(
     script.assert_not_installed("base", "other")
 
 
+def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_succeed(
+    script: PipTestEnvironment,
+) -> None:
+    """Regression test: a package that is only pulled in transitively (never
+    required directly) must still have its hash enforced when constrained in
+    URL form. Unlike test_new_resolver_hash_requirement_and_url_constraint_*
+    above (where the constrained package is also a direct requirement, so the
+    resolver has an already-hashed template to fall back on), "dep" here is
+    never a direct requirement -- the constraint is the only source of a hash
+    for it.
+    """
+    base_path = create_basic_wheel_for_package(
+        script, "base", "0.1.0", depends=["dep"]
+    )
+    base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
+    dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
+    dep_hash = hashlib.sha256(dep_path.read_bytes()).hexdigest()
+
+    requirements_txt = script.scratch_path / "requirements.txt"
+    requirements_txt.write_text(f"base==0.1.0 --hash=sha256:{base_hash}\n")
+
+    constraints_txt = script.scratch_path / "constraints.txt"
+    constraints_txt.write_text(f"dep @ {dep_path.as_uri()} --hash=sha256:{dep_hash}\n")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--constraint",
+        constraints_txt,
+        "--requirement",
+        requirements_txt,
+    )
+
+    script.assert_installed(base="0.1.0", dep="0.1.0")
+
+
+def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_fail(
+    script: PipTestEnvironment,
+) -> None:
+    """Same as the "can_succeed" case above, but with a tampered hash on the
+    URL-form constraint for the transitively-needed package -- must still be
+    rejected, not silently accepted just because the hash came from a
+    constraint rather than a direct requirement.
+    """
+    base_path = create_basic_wheel_for_package(
+        script, "base", "0.1.0", depends=["dep"]
+    )
+    base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
+    dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
+    other_path = create_basic_wheel_for_package(script, "other", "0.1.0")
+    other_hash = hashlib.sha256(other_path.read_bytes()).hexdigest()
+
+    requirements_txt = script.scratch_path / "requirements.txt"
+    requirements_txt.write_text(f"base==0.1.0 --hash=sha256:{base_hash}\n")
+
+    constraints_txt = script.scratch_path / "constraints.txt"
+    constraints_txt.write_text(
+        f"dep @ {dep_path.as_uri()} --hash=sha256:{other_hash}\n"
+    )
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--constraint",
+        constraints_txt,
+        "--requirement",
+        requirements_txt,
+        expect_error=True,
+    )
+
+    assert (
+        "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE."
+    ) in result.stderr, str(result)
+
+    script.assert_not_installed("base", "dep")
+
+
 def test_new_resolver_unpinned_requirement_with_pinned_hash_constraint(
     script: PipTestEnvironment,
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

If a constraint is given in url-form (`name @ url --hash=...`), this cannot be parsed, and the hash value gets lost.

If using `--require-hashes` or a single hash value is present in non url-form, pip aborts the installation because of a missing hash value for requirements defined in url-form. This is not security-related, because the installation will fail loudly, but it breaks the installation process of applications.

This PR adds a fallback to the `hash_options` from the constraints .

Two new tests were added for transitive dependencies.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude Code, used to analyse pip's resolver/constraint internals and help identify and validate the root cause of this bug.
