### PR TITLE
Support pylock.toml as a constraints source (-c, --build-constraint, PIP_CONSTRAINT)

### DIFF
--- a/news/13961.feature.rst
+++ b/news/13961.feature.rst
@@ -1,0 +1,3 @@
+Support reading constraints (``-c``/``--constraint``, ``PIP_CONSTRAINT``,
+and ``--build-constraint``) from a ``pylock.toml`` file, mirroring the
+existing experimental support for ``-r``/``--requirement``.

--- a/news/14284.bugfix.rst
+++ b/news/14284.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a constraint's hash being ignored for a package that is only needed
+transitively, when the constraint is given in URL form (``name @ url --hash=...``).

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -569,6 +569,8 @@ def constraints() -> Option:
         default=[],
         metavar="file",
         help="Constrain versions using the given constraints file. "
+        "The file or URL can be in pip's requirements.txt format, "
+        "or pylock.toml format. pylock.toml support is experimental. "
         "This option can be used multiple times.",
     )
 
@@ -583,6 +585,8 @@ def build_constraints() -> Option:
         metavar="file",
         help=(
             "Constrain build dependencies using the given constraints file. "
+            "The file or URL can be in pip's requirements.txt format, "
+            "or pylock.toml format. pylock.toml support is experimental. "
             "This option can be used multiple times."
         ),
     )

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -122,6 +122,31 @@ def parse_constraint_files(
 ) -> list[InstallRequirement]:
     requirements = []
     for filename in constraint_files:
+        if is_valid_pylock_filename(filename):
+            logger.warning(
+                "Using pylock.toml as a constraints source "
+                "is an experimental feature. "
+                "It may be removed/changed in a future release "
+                "without prior warning."
+            )
+            for package, package_dist in select_from_pylock_path_or_url(
+                filename, session=session
+            ):
+                req_to_add, locked_link = install_req_from_pylock_package(
+                    package,
+                    package_dist,
+                    filename,
+                    user_supplied=False,
+                    constraint=True,
+                )
+                requirements.append(req_to_add)
+                if locked_link:
+                    # Covers an unpinned/transitive reference to the
+                    # constrained package; req_to_add.link (see
+                    # install_req_from_pylock_package()) covers the
+                    # complementary already-pinned-elsewhere case.
+                    finder.add_locked_link(package.name, locked_link)
+            continue
         for parsed_req in parse_requirements(
             filename,
             constraint=True,

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -585,11 +585,18 @@ def install_req_from_pylock_package(
     ),
     pylock_path_or_url: str,
     user_supplied: bool,
+    constraint: bool = False,
 ) -> tuple[InstallRequirement, Link | None]:
     """Construct an InstallRequirement from a pylock package and artifact.
 
     If the artifact is a Sdist or Wheel, also return a locked Link which
     is meant to override candidates from indexes or --find-links.
+
+    ``constraint=True`` is only meaningful for Wheel/Sdist (the only forms
+    that produce a plain ``name==version`` requirement); for VCS/Archive/
+    editable-Directory it still builds the requirement so pip's existing
+    constraint-type validation rejects it with its normal error, same as
+    a classic URL-form ``-c`` constraint already is.
     """
     # TODO: validate file size
     if isinstance(package_dist, pylock.PackageVcs):
@@ -599,6 +606,7 @@ def install_req_from_pylock_package(
                 req=Requirement(f"{package.name} @ {req_url}"),
                 comes_from=pylock_path_or_url,
                 user_supplied=user_supplied,
+                constraint=constraint,
             ),
             None,
         )
@@ -610,6 +618,7 @@ def install_req_from_pylock_package(
                 comes_from=pylock_path_or_url,
                 hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
                 user_supplied=user_supplied,
+                constraint=constraint,
             ),
             None,
         )
@@ -621,6 +630,7 @@ def install_req_from_pylock_package(
                     req_url,
                     comes_from=pylock_path_or_url,
                     user_supplied=user_supplied,
+                    constraint=constraint,
                 ),
                 None,
             )
@@ -630,6 +640,7 @@ def install_req_from_pylock_package(
                     req_url,
                     comes_from=pylock_path_or_url,
                     user_supplied=user_supplied,
+                    constraint=constraint,
                 ),
                 None,
             )
@@ -648,15 +659,27 @@ def install_req_from_pylock_package(
             requirement_url = package_sdist_requirement_url(
                 pylock_path_or_url, package_dist
             )
+        # hashes= (not just hash_options on the ireq below): needed so
+        # Constraint.from_ireq()/InstallRequirement.hashes() can still find
+        # the hash when this Link is used to build a resolver candidate --
+        # see the factory.py comment in _iter_candidates_from_constraints().
+        locked_link = Link(
+            requirement_url,
+            comes_from=pylock_path_or_url,
+            upload_time=package_dist.upload_time,
+            hashes=dict(package_dist.hashes),
+        )
         ireq = InstallRequirement(
             req=Requirement(f"{package.name}=={version}"),
             comes_from=pylock_path_or_url,
             hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
             user_supplied=user_supplied,
-        )
-        locked_link = Link(
-            requirement_url,
-            comes_from=pylock_path_or_url,
-            upload_time=package_dist.upload_time,
+            constraint=constraint,
+            # Only for constraints: an already-pinned requirement given
+            # elsewhere (`-c pylock.toml foo==1.0`) resolves via its own
+            # candidate lookup, never consulting the finder's locked links
+            # (registered separately by the caller from the returned Link)
+            # -- it needs the hash on this ireq's own .link to be found.
+            link=locked_link if constraint else None,
         )
         return ireq, locked_link

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -396,6 +396,15 @@ class Factory:
                 base_identifier = canonicalize_name(parsed_requirement.name)
                 extras = frozenset(parsed_requirement.extras)
 
+        # install_req_from_link_and_ireq() below copies hash_options from
+        # *template*, which for a transitively-needed package is the
+        # requirement that pulled it in, not the constraint -- fall back to
+        # the constraint's own hashes, same as _iter_found_candidates() does.
+        if constraint.hash_options and not template.hash_options:
+            template = copy.copy(template)
+            template.hash_options = {
+                k: list(v) for k, v in constraint.hash_options.items()
+            }
         for link in constraint.links:
             self._fail_if_link_is_unsupported_wheel(link)
             base_candidate = self._make_base_candidate_from_link(

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -42,6 +44,44 @@ def _create_constraints_file(
     return constraints_file
 
 
+def _create_pylock_build_constraints_file(
+    script: PipTestEnvironment, data: TestData, filename: str, package: str
+) -> Path:
+    """Create a pylock.toml build-constraints file pinning *package* to
+    whichever matching wheel exists in common_wheels, hash computed on
+    the spot rather than hardcoded."""
+    wheel_candidates = list(data.common_wheels.glob(f"{package}-*.whl"))
+    assert len(wheel_candidates) == 1, (
+        f"expected exactly one {package} wheel in {data.common_wheels}, "
+        f"got {wheel_candidates}"
+    )
+    wheel_path = wheel_candidates[0]
+    digest = hashlib.sha256(wheel_path.read_bytes()).hexdigest()
+    # "name==version" parsed from the wheel filename's first two `-`-separated
+    # segments, same convention the wheel filename spec itself uses.
+    name, version = wheel_path.name.split("-")[:2]
+
+    pylock_path = script.scratch_path / filename
+    pylock_path.write_text(
+        f"""\
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "{name}"
+version = "{version}"
+
+[[packages.wheels]]
+name = "{wheel_path.name}"
+path = "{wheel_path}"
+
+[packages.wheels.hashes]
+sha256 = "{digest}"
+"""
+    )
+    return pylock_path
+
+
 def _run_pip_install_with_build_constraints(
     script: PipTestEnvironment,
     data: TestData,
@@ -49,6 +89,7 @@ def _run_pip_install_with_build_constraints(
     build_constraints_file: Path,
     extra_args: list[str] | None = None,
     expect_error: bool = False,
+    **kwargs: Any,
 ) -> TestPipResult:
     """Run pip install with build constraints and common arguments."""
     args = [
@@ -67,6 +108,36 @@ def _run_pip_install_with_build_constraints(
         expect_error=expect_error,
         build_isolation=True,
         find_links=data.common_wheels,
+        **kwargs,
+    )
+
+
+def test_build_constraints_pylock(
+    script: PipTestEnvironment, data: TestData, tmpdir: Path
+) -> None:
+    """Same as test_build_constraints_basic_functionality_simple, but with
+    the build constraint coming from a pylock.toml file instead."""
+    project_dir = _create_simple_test_package(
+        script=script, name="test_build_constraints_pylock"
+    )
+    pylock_path = _create_pylock_build_constraints_file(
+        script=script,
+        data=data,
+        filename="pylock.buildconstraint.toml",
+        package="setuptools",
+    )
+    result = _run_pip_install_with_build_constraints(
+        script=script,
+        data=data,
+        project_dir=project_dir,
+        build_constraints_file=pylock_path,
+        allow_stderr_warning=True,
+    )
+    # The experimental-pylock warning is logged inside the isolated
+    # build-dependency subprocess, not visible in the outer stderr here;
+    # the install succeeding proves the constraint was read and enforced.
+    result.assert_installed(
+        "test-build-constraints-pylock", editable=False, without_files=["."]
     )
 
 

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -72,7 +72,7 @@ version = "{version}"
 
 [[packages.wheels]]
 name = "{wheel_path.name}"
-path = "{wheel_path}"
+path = "{wheel_path.as_posix()}"
 
 [packages.wheels.hashes]
 sha256 = "{digest}"

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -62,8 +62,7 @@ def _create_pylock_build_constraints_file(
     name, version = wheel_path.name.split("-")[:2]
 
     pylock_path = script.scratch_path / filename
-    pylock_path.write_text(
-        f"""\
+    pylock_path.write_text(f"""\
 lock-version = "1.0"
 created-by = "pip"
 
@@ -77,8 +76,7 @@ path = "{wheel_path}"
 
 [packages.wheels.hashes]
 sha256 = "{digest}"
-"""
-    )
+""")
     return pylock_path
 
 

--- a/tests/functional/test_install_pylock_constraints.py
+++ b/tests/functional/test_install_pylock_constraints.py
@@ -1,0 +1,143 @@
+"""Tests for using pylock.toml files as constraints (-c/--constraint,
+PIP_CONSTRAINT, --build-constraint), mirroring the coverage in
+test_install_pylock_reqs.py for the analogous -r/--requirement case."""
+
+import json
+
+from tests.lib import PipTestEnvironment, TestData
+
+
+def test_constraint_pylock_narrows_unpinned_requirement(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """The main target use case: an otherwise-unpinned requirement gets
+    narrowed to the exact version+hash recorded in the pylock.toml
+    constraint."""
+    pylock_path = data.lockfiles.joinpath("pylock.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,
+        "--quiet",
+        "--report",
+        "-",
+        "--dry-run",
+        "-c",
+        pylock_path,
+        "simplewheel",
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    report = json.loads(result.stdout)
+    installed = report["install"]
+    assert [
+        (r["metadata"]["name"], r["metadata"]["version"], r["requested"])
+        for r in installed
+    ] == [("simplewheel", "2.0", True)]
+
+
+def test_constraint_pylock_unused_entry_not_installed(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """A package constrained via pylock.toml but not required by anything
+    else must not be installed -- constraints only narrow, they never
+    force installation on their own (same guarantee as classic -c)."""
+    pylock_path = data.lockfiles.joinpath("pylock.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,
+        "--quiet",
+        "--report",
+        "-",
+        "--dry-run",
+        "-c",
+        pylock_path,
+        "simplewheel",
+        allow_stderr_warning=True,
+    )
+    report = json.loads(result.stdout)
+    installed_names = {r["metadata"]["name"] for r in report["install"]}
+    # pylock.toml also constrains "simple" (sdist) and "simple2" (archive),
+    # neither requested here -- they must be absent.
+    assert installed_names == {"simplewheel"}
+
+
+def test_constraint_pylock_invalid_hash(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.invalidhash.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.find_links,
+        "--dry-run",
+        "-c",
+        pylock_path,
+        # Exact-pinned: a bare name fails earlier on HashUnpinned, before
+        # reaching the hash-comparison this test exercises. Also covers
+        # the hash coming from the constraint for an already-pinned
+        # requirement, not from the requirement itself.
+        "simple==2.0",
+        expect_error=True,
+    )
+    assert (
+        "Expected sha256 "
+        "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a0"
+        in result.stderr
+    )
+    assert (
+        "Got        3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"
+        in result.stderr
+    )
+
+
+def test_constraint_pylock_editable_rejected(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """pylock.toml directory entries marked editable must be rejected as
+    constraints, exactly like a classic editable -c entry already is --
+    a constraint can only narrow a name+version, never carry install
+    instructions of its own."""
+    pylock_path = data.lockfiles.joinpath("pylock.directory.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,
+        "--dry-run",
+        "-c",
+        pylock_path,
+        "simplewheel",
+        expect_error=True,
+    )
+    assert "Editable requirements are not allowed as constraints" in result.stderr
+
+
+def test_constraint_pylock_invalid_lockfile(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.invalid.toml")
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-c", pylock_path, expect_error=True
+    )
+    assert "Invalid pylock file" in result.stderr
+
+
+def test_constraint_pylock_not_found(
+    script: PipTestEnvironment,
+    tmp_path: object,
+) -> None:
+    pylock_path = str(tmp_path) + "/pylock.doesnotexist.toml"  # type: ignore[operator]
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-c", pylock_path, expect_error=True
+    )
+    assert "Error reading pylock file" in result.stderr

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -301,9 +301,7 @@ def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_succeed(
     never a direct requirement -- the constraint is the only source of a hash
     for it.
     """
-    base_path = create_basic_wheel_for_package(
-        script, "base", "0.1.0", depends=["dep"]
-    )
+    base_path = create_basic_wheel_for_package(script, "base", "0.1.0", depends=["dep"])
     base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
     dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
     dep_hash = hashlib.sha256(dep_path.read_bytes()).hexdigest()
@@ -337,9 +335,7 @@ def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_fail(
     rejected, not silently accepted just because the hash came from a
     constraint rather than a direct requirement.
     """
-    base_path = create_basic_wheel_for_package(
-        script, "base", "0.1.0", depends=["dep"]
-    )
+    base_path = create_basic_wheel_for_package(script, "base", "0.1.0", depends=["dep"])
     base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
     dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
     other_path = create_basic_wheel_for_package(script, "other", "0.1.0")

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -290,6 +290,89 @@ def test_new_resolver_hash_requirement_and_url_constraint_can_fail(
     script.assert_not_installed("base", "other")
 
 
+def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_succeed(
+    script: PipTestEnvironment,
+) -> None:
+    """Regression test: a package that is only pulled in transitively (never
+    required directly) must still have its hash enforced when constrained in
+    URL form. Unlike test_new_resolver_hash_requirement_and_url_constraint_*
+    above (where the constrained package is also a direct requirement, so the
+    resolver has an already-hashed template to fall back on), "dep" here is
+    never a direct requirement -- the constraint is the only source of a hash
+    for it.
+    """
+    base_path = create_basic_wheel_for_package(
+        script, "base", "0.1.0", depends=["dep"]
+    )
+    base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
+    dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
+    dep_hash = hashlib.sha256(dep_path.read_bytes()).hexdigest()
+
+    requirements_txt = script.scratch_path / "requirements.txt"
+    requirements_txt.write_text(f"base==0.1.0 --hash=sha256:{base_hash}\n")
+
+    constraints_txt = script.scratch_path / "constraints.txt"
+    constraints_txt.write_text(f"dep @ {dep_path.as_uri()} --hash=sha256:{dep_hash}\n")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--constraint",
+        constraints_txt,
+        "--requirement",
+        requirements_txt,
+    )
+
+    script.assert_installed(base="0.1.0", dep="0.1.0")
+
+
+def test_new_resolver_hash_url_constraint_for_transitive_dependency_can_fail(
+    script: PipTestEnvironment,
+) -> None:
+    """Same as the "can_succeed" case above, but with a tampered hash on the
+    URL-form constraint for the transitively-needed package -- must still be
+    rejected, not silently accepted just because the hash came from a
+    constraint rather than a direct requirement.
+    """
+    base_path = create_basic_wheel_for_package(
+        script, "base", "0.1.0", depends=["dep"]
+    )
+    base_hash = hashlib.sha256(base_path.read_bytes()).hexdigest()
+    dep_path = create_basic_wheel_for_package(script, "dep", "0.1.0")
+    other_path = create_basic_wheel_for_package(script, "other", "0.1.0")
+    other_hash = hashlib.sha256(other_path.read_bytes()).hexdigest()
+
+    requirements_txt = script.scratch_path / "requirements.txt"
+    requirements_txt.write_text(f"base==0.1.0 --hash=sha256:{base_hash}\n")
+
+    constraints_txt = script.scratch_path / "constraints.txt"
+    constraints_txt.write_text(
+        f"dep @ {dep_path.as_uri()} --hash=sha256:{other_hash}\n"
+    )
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--constraint",
+        constraints_txt,
+        "--requirement",
+        requirements_txt,
+        expect_error=True,
+    )
+
+    assert (
+        "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE."
+    ) in result.stderr, str(result)
+
+    script.assert_not_installed("base", "dep")
+
+
 def test_new_resolver_unpinned_requirement_with_pinned_hash_constraint(
     script: PipTestEnvironment,
 ) -> None:


### PR DESCRIPTION
**Draft note:** non-collaborators are limited to one open (non-draft) PR at a time on
this repo, and #14284 already counted against that — marking this one ready for review
as soon as #14284 merges. It's otherwise complete and tested, not a WIP.

## What does this PR do?

Mirrors the existing experimental `-r`/`--requirement` pylock.toml support (gh-13876)
for the constraint side: `parse_constraint_files()` now recognizes `pylock.toml`
filenames the same way `-r` already does, and builds requirements via
`install_req_from_pylock_package(constraint=True)` instead of the classic line parser.
Since `--build-constraint` and `PIP_CONSTRAINT` both feed into the same function, this
covers all three constraint paths in one change — previously none of them understood
`pylock.toml`.

Depends on #14284: while testing this against a build backend with a real dependency
tree (`hatchling`, which pulls in `packaging`/`pathspec`/`pluggy`/`trove-classifiers`),
I found a pre-existing resolver bug that this feature triggers reliably, since
`pylock.toml` wheel/sdist entries are structurally always URL-form constraints — fixed
separately in #14284, not part of this PR's diff. GitHub doesn't support stacking PRs
across a fork, so this PR's diff currently also includes #14284's two commits; they'll
drop out automatically once #14284 merges into `main`.

Fixes #13961.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude Code, used to analyse pip's resolver/constraint internals and help identify and validate the root cause of the transitive-hash bug fixed in #14284.
