### PR TITLE
Remove obsolete tar extraction fallback

### DIFF
--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -190,171 +190,61 @@ def untar_file(filename: str, location: str) -> None:
     try:
         leading = has_leading_dir([member.name for member in tar.getmembers()])
 
-        # PEP 706 added `tarfile.data_filter`, and made some other changes to
-        # Python's tarfile module (see below). The features were backported to
-        # security releases.
-        try:
-            data_filter = tarfile.data_filter
-        except AttributeError:
-            _untar_without_filter(filename, location, tar, leading)
-        else:
-            default_mode_plus_executable = _get_default_mode_plus_executable()
+        default_mode_plus_executable = _get_default_mode_plus_executable()
 
-            if leading:
-                # Strip the leading directory from all files in the archive,
-                # including hardlink targets (which are relative to the
-                # unpack location).
-                for member in tar.getmembers():
-                    name_lead, name_rest = split_leading_dir(member.name)
-                    member.name = name_rest
-                    if member.islnk():
-                        lnk_lead, lnk_rest = split_leading_dir(member.linkname)
-                        if lnk_lead == name_lead:
-                            member.linkname = lnk_rest
+        if leading:
+            # Strip the leading directory from all files in the archive,
+            # including hardlink targets (which are relative to the
+            # unpack location).
+            for member in tar.getmembers():
+                name_lead, name_rest = split_leading_dir(member.name)
+                member.name = name_rest
+                if member.islnk():
+                    lnk_lead, lnk_rest = split_leading_dir(member.linkname)
+                    if lnk_lead == name_lead:
+                        member.linkname = lnk_rest
 
-            def pip_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo:
-                orig_mode = member.mode
+        def pip_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo:
+            orig_mode = member.mode
+            try:
                 try:
-                    try:
-                        member = data_filter(member, location)
-                    except tarfile.LinkOutsideDestinationError:
-                        if sys.version_info[:3] in {
-                            (3, 9, 17),
-                            (3, 10, 12),
-                            (3, 11, 4),
-                        }:
-                            # The tarfile filter in specific Python versions
-                            # raises LinkOutsideDestinationError on valid input
-                            # (https://github.com/python/cpython/issues/107845)
-                            # Ignore the error there, but do use the
-                            # more lax `tar_filter`
-                            member = tarfile.tar_filter(member, location)
-                        else:
-                            raise
-                except tarfile.TarError as exc:
-                    message = "Invalid member in the tar file {}: {}"
-                    # Filter error messages mention the member name.
-                    # No need to add it here.
-                    raise InstallationError(
-                        message.format(
-                            filename,
-                            exc,
-                        )
+                    member = tarfile.data_filter(member, location)
+                except tarfile.LinkOutsideDestinationError:
+                    if sys.version_info[:3] in {
+                        (3, 10, 12),
+                        (3, 11, 4),
+                    }:
+                        # The tarfile filter in specific Python versions
+                        # raises LinkOutsideDestinationError on valid input
+                        # (https://github.com/python/cpython/issues/107845)
+                        # Ignore the error there, but do use the
+                        # more lax `tar_filter`
+                        member = tarfile.tar_filter(member, location)
+                    else:
+                        raise
+            except tarfile.TarError as exc:
+                message = "Invalid member in the tar file {}: {}"
+                # Filter error messages mention the member name.
+                # No need to add it here.
+                raise InstallationError(
+                    message.format(
+                        filename,
+                        exc,
                     )
-                if member.isfile() and orig_mode & 0o111:
-                    member.mode = default_mode_plus_executable
-                else:
-                    # See PEP 706 note above.
-                    # The PEP changed this from `int` to `Optional[int]`,
-                    # where None means "use the default". Mypy doesn't
-                    # know this yet.
-                    member.mode = None  # type: ignore [assignment]
-                return member
+                )
+            if member.isfile() and orig_mode & 0o111:
+                member.mode = default_mode_plus_executable
+            else:
+                # PEP 706 changed this from `int` to `Optional[int]`,
+                # where None means "use the default". Mypy doesn't
+                # know this yet.
+                member.mode = None  # type: ignore [assignment]
+            return member
 
-            tar.extractall(location, filter=pip_filter)
+        tar.extractall(location, filter=pip_filter)
 
     finally:
         tar.close()
-
-
-def is_symlink_target_in_tar(tar: tarfile.TarFile, tarinfo: tarfile.TarInfo) -> bool:
-    """Check if the file pointed to by the symbolic link is in the tar archive"""
-    linkname = os.path.join(os.path.dirname(tarinfo.name), tarinfo.linkname)
-
-    linkname = os.path.normpath(linkname)
-    linkname = linkname.replace("\\", "/")
-
-    try:
-        tar.getmember(linkname)
-        return True
-    except KeyError:
-        return False
-
-
-def _untar_without_filter(
-    filename: str,
-    location: str,
-    tar: tarfile.TarFile,
-    leading: bool,
-) -> None:
-    """Fallback for Python without tarfile.data_filter"""
-    # NOTE: This function can be removed once pip requires CPython ≥ 3.12.​
-    # PEP 706 added tarfile.data_filter, made tarfile extraction operations more secure.
-    # This feature is fully supported from CPython 3.12 onward.
-    for member in tar.getmembers():
-        fn = member.name
-        if leading:
-            fn = split_leading_dir(fn)[1]
-        path = os.path.join(location, fn)
-
-        # The plain check rejects textual ".." escapes; resolving symlinks also
-        # catches a later member redirected outside by an earlier member's
-        # symlink (e.g. "link/../file").
-        if not is_within_directory(location, path) or not is_within_directory(
-            location, path, resolve_symlinks=True
-        ):
-            message = (
-                "The tar file ({}) has a file ({}) trying to install "
-                "outside target directory ({})"
-            )
-            raise InstallationError(message.format(filename, path, location))
-        if member.isdir():
-            ensure_dir(path)
-        elif member.issym():
-            # Reject symlinks resolving outside the destination, so a later
-            # member cannot be written through them.
-            target = os.path.join(os.path.dirname(path), member.linkname)
-            if not is_within_directory(location, target, resolve_symlinks=True):
-                message = (
-                    "The tar file ({}) has a file ({}) trying to install "
-                    "outside target directory ({})"
-                )
-                raise InstallationError(
-                    message.format(filename, member.name, member.linkname)
-                )
-            if not is_symlink_target_in_tar(tar, member):
-                message = (
-                    "The tar file ({}) has a file ({}) trying to install "
-                    "outside target directory ({})"
-                )
-                raise InstallationError(
-                    message.format(filename, member.name, member.linkname)
-                )
-            try:
-                tar._extract_member(member, path)
-            except Exception as exc:
-                # Some corrupt tar files seem to produce this
-                # (specifically bad symlinks)
-                logger.warning(
-                    "In the tar file %s the member %s is invalid: %s",
-                    filename,
-                    member.name,
-                    exc,
-                )
-                continue
-        else:
-            try:
-                fp = tar.extractfile(member)
-            except (KeyError, AttributeError) as exc:
-                # Some corrupt tar files seem to produce this
-                # (specifically bad symlinks)
-                logger.warning(
-                    "In the tar file %s the member %s is invalid: %s",
-                    filename,
-                    member.name,
-                    exc,
-                )
-                continue
-            ensure_dir(os.path.dirname(path))
-            assert fp is not None
-            with open(path, "wb") as destfp:
-                shutil.copyfileobj(fp, destfp)
-            fp.close()
-            # Update the timestamp (useful for cython compiled files)
-            tar.utime(member, path)
-            # member have any execute permissions for user/group/world?
-            if member.mode & 0o111:
-                set_extracted_file_to_default_mode_plus_executable(path)
 
 
 def unpack_file(

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -241,7 +241,8 @@ def untar_file(filename: str, location: str) -> None:
                 member.mode = None  # type: ignore [assignment]
             return member
 
-        tar.extractall(location, filter=pip_filter)
+        members = (pip_filter(member, location) for member in tar.getmembers())
+        tar.extractall(location, members=members)
 
     finally:
         tar.close()

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.unpacking import (
@@ -201,12 +200,7 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(test_tar, self.tempdir)
 
-        # The error message comes from tarfile.data_filter when it is available,
-        # otherwise from pip's own check.
-        if hasattr(tarfile, "data_filter"):
-            assert "is outside the destination" in str(e.value)
-        else:
-            assert "trying to install outside target directory" in str(e.value)
+        assert "is outside the destination" in str(e.value)
 
     def test_unpack_tar_success(self) -> None:
         """
@@ -222,10 +216,6 @@ class TestUnpackArchives:
         test_tar = self.make_tar_file("test_tar.tar", files)
         untar_file(test_tar, self.tempdir)
 
-    @pytest.mark.skipif(
-        not hasattr(tarfile, "data_filter"),
-        reason="tarfile filters (PEP-721) not available",
-    )
     def test_unpack_tar_filter(self) -> None:
         """
         Test that the tarfile.data_filter is used to disallow dangerous
@@ -282,216 +272,6 @@ class TestUnpackArchives:
 
         with open(os.path.join(unpack_dir, "symlink.txt"), "rb") as f:
             assert f.read() == content
-
-    def test_unpack_normal_tar_link1_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """
-        Test unpacking a normal tar with file containing soft links, but no data_filter
-        """
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filename = "test_tar_links_no_data_filter.tar"
-        tar_filepath = os.path.join(self.tempdir, tar_filename)
-
-        extract_path = os.path.join(self.tempdir, "extract_path")
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            file_data = io.BytesIO(b"normal\n")
-            normal_file_tarinfo = tarfile.TarInfo(name="normal_file")
-            normal_file_tarinfo.size = len(file_data.getbuffer())
-            tar.addfile(normal_file_tarinfo, fileobj=file_data)
-
-            info = tarfile.TarInfo("normal_symlink")
-            info.type = tarfile.SYMTYPE
-            info.linkpath = "normal_file"
-            tar.addfile(info)
-
-        untar_file(tar_filepath, extract_path)
-
-        assert os.path.islink(os.path.join(extract_path, "normal_symlink"))
-
-        link_path = os.readlink(os.path.join(extract_path, "normal_symlink"))
-        assert link_path == "normal_file"
-
-        with open(os.path.join(extract_path, "normal_symlink"), "rb") as f:
-            assert f.read() == b"normal\n"
-
-    def test_unpack_normal_tar_link2_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """
-        Test unpacking a normal tar with file containing soft links, but no data_filter
-        """
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filename = "test_tar_links_no_data_filter.tar"
-        tar_filepath = os.path.join(self.tempdir, tar_filename)
-
-        extract_path = os.path.join(self.tempdir, "extract_path")
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            file_data = io.BytesIO(b"normal\n")
-            normal_file_tarinfo = tarfile.TarInfo(name="normal_file")
-            normal_file_tarinfo.size = len(file_data.getbuffer())
-            tar.addfile(normal_file_tarinfo, fileobj=file_data)
-
-            info = tarfile.TarInfo("sub/normal_symlink")
-            info.type = tarfile.SYMTYPE
-            info.linkpath = ".." + os.path.sep + "normal_file"
-            tar.addfile(info)
-
-        untar_file(tar_filepath, extract_path)
-
-        assert os.path.islink(os.path.join(extract_path, "sub", "normal_symlink"))
-
-        link_path = os.readlink(os.path.join(extract_path, "sub", "normal_symlink"))
-        assert link_path == ".." + os.path.sep + "normal_file"
-
-        with open(os.path.join(extract_path, "sub", "normal_symlink"), "rb") as f:
-            assert f.read() == b"normal\n"
-
-    def test_unpack_evil_tar_link1_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """
-        Test unpacking a evil tar with file containing soft links, but no data_filter
-        """
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filename = "test_tar_links_no_data_filter.tar"
-        tar_filepath = os.path.join(self.tempdir, tar_filename)
-
-        import_filename = "import_file"
-        import_filepath = os.path.join(self.tempdir, import_filename)
-        open(import_filepath, "w").close()
-
-        extract_path = os.path.join(self.tempdir, "extract_path")
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            info = tarfile.TarInfo("evil_symlink")
-            info.type = tarfile.SYMTYPE
-            info.linkpath = import_filepath
-            tar.addfile(info)
-
-        with pytest.raises(InstallationError) as e:
-            untar_file(tar_filepath, extract_path)
-
-        msg = (
-            "The tar file ({}) has a file ({}) trying to install outside "
-            "target directory ({})"
-        )
-        assert msg.format(tar_filepath, "evil_symlink", import_filepath) in str(e.value)
-
-        assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
-
-    def test_unpack_evil_tar_link2_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """
-        Test unpacking a evil tar with file containing soft links, but no data_filter
-        """
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filename = "test_tar_links_no_data_filter.tar"
-        tar_filepath = os.path.join(self.tempdir, tar_filename)
-
-        import_filename = "import_file"
-        import_filepath = os.path.join(self.tempdir, import_filename)
-        open(import_filepath, "w").close()
-
-        extract_path = os.path.join(self.tempdir, "extract_path")
-
-        link_path = ".." + os.sep + import_filename
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            info = tarfile.TarInfo("evil_symlink")
-            info.type = tarfile.SYMTYPE
-            info.linkpath = link_path
-            tar.addfile(info)
-
-        with pytest.raises(InstallationError) as e:
-            untar_file(tar_filepath, extract_path)
-
-        msg = (
-            "The tar file ({}) has a file ({}) trying to install outside "
-            "target directory ({})"
-        )
-        assert msg.format(tar_filepath, "evil_symlink", link_path) in str(e.value)
-
-        assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
-
-    def test_unpack_tar_symlink_then_member_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """Reject a symlink to outside before a member is written through it."""
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filepath = os.path.join(self.tempdir, "symlink_then_member.tar")
-        extract_path = os.path.join(self.tempdir, "extract_path")
-        outside_path = os.path.join(self.tempdir, "outside.txt")
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            info = tarfile.TarInfo("outside_link")
-            info.type = tarfile.SYMTYPE
-            info.linkname = ".."
-            tar.addfile(info)
-
-            data = io.BytesIO(b"data\n")
-            info = tarfile.TarInfo("outside_link/outside.txt")
-            info.size = len(data.getbuffer())
-            tar.addfile(info, fileobj=data)
-
-            info = tarfile.TarInfo("..")
-            info.type = tarfile.DIRTYPE
-            tar.addfile(info)
-
-        with pytest.raises(InstallationError):
-            untar_file(tar_filepath, extract_path)
-
-        assert not os.path.exists(outside_path)
-        assert not os.path.exists(os.path.join(extract_path, "outside_link"))
-
-    def test_unpack_tar_nested_symlink_traversal_no_data_filter(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
-        """Reject a member that escapes through a chain of in-bounds symlinks."""
-        if hasattr(tarfile, "data_filter"):
-            monkeypatch.delattr("tarfile.data_filter")
-
-        tar_filepath = os.path.join(self.tempdir, "nested_traversal.tar")
-        extract_path = os.path.join(self.tempdir, "extract_path")
-        outside_path = os.path.join(self.tempdir, "outside.txt")
-
-        with tarfile.open(tar_filepath, "w") as tar:
-            info = tarfile.TarInfo(".")
-            info.type = tarfile.DIRTYPE
-            tar.addfile(info)
-
-            info = tarfile.TarInfo("redir")
-            info.type = tarfile.SYMTYPE
-            info.linkname = "."
-            tar.addfile(info)
-
-            info = tarfile.TarInfo("redir/up")
-            info.type = tarfile.SYMTYPE
-            info.linkname = ".."
-            tar.addfile(info)
-
-            data = io.BytesIO(b"data\n")
-            info = tarfile.TarInfo("redir/up/outside.txt")
-            info.size = len(data.getbuffer())
-            tar.addfile(info, fileobj=data)
-
-        with pytest.raises(InstallationError):
-            untar_file(tar_filepath, extract_path)
-
-        assert not os.path.exists(outside_path)
 
 
 def test_unpack_tar_unicode(tmpdir: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Remove `_untar_without_filter` and its associated compatibility tests now that `tarfile.data_filter` is available on every supported Python version.

This leaves one maintained extraction path using the standard library security filter and removes the parallel custom implementation.

Closes #14241.

## PR Checklist

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment.
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file and disclosed AI tool use below.

Assisted-by: OpenAI Codex

## Tests

- `nox -s test-3.12 -- tests/unit/test_utils_unpacking.py` - 57 passed
- File-scoped pre-commit checks - passed
- Focused archive matrix covering normal files, hard links, symbolic links, path traversal and external links - passed
- `git diff --check` - passed