### PR TITLE
Unset GIT_INDEX_FILE for git+ VCS subprocesses

### DIFF
--- a/news/14290.bugfix.rst
+++ b/news/14290.bugfix.rst
@@ -1,0 +1,5 @@
+Unset ``GIT_INDEX_FILE`` (in addition to the already-unset ``GIT_DIR`` and
+``GIT_WORK_TREE``) before running git subprocesses for ``git+`` VCS installs,
+preventing an ambient ``GIT_INDEX_FILE`` (e.g. one set by git itself when
+invoking hooks) from causing pip's git operations to write into an unrelated
+repository's index.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -71,11 +71,8 @@ class Git(VersionControl):
     )
     # Prevent the user's environment variables from interfering with pip:
     # https://github.com/pypa/pip/issues/1130
-    # GIT_INDEX_FILE is also unset: git sets it when invoking hooks (e.g.
-    # pre-commit), pointing at the index of the repo being committed. If a
-    # hook runs a `git+`-VCS pip install, the inherited GIT_INDEX_FILE
-    # causes pip's own `git checkout` (in its own throwaway clone) to write
-    # into the hook-invoking repo's index instead of its own, corrupting it.
+    # GIT_INDEX_FILE is also unset, since git sets it for hooks and it can
+    # otherwise leak into pip's own git subprocesses:
     # https://github.com/pypa/pip/issues/14290
     unset_environ = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
     default_arg_rev = "HEAD"

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -71,7 +71,13 @@ class Git(VersionControl):
     )
     # Prevent the user's environment variables from interfering with pip:
     # https://github.com/pypa/pip/issues/1130
-    unset_environ = ("GIT_DIR", "GIT_WORK_TREE")
+    # GIT_INDEX_FILE is also unset: git sets it when invoking hooks (e.g.
+    # pre-commit), pointing at the index of the repo being committed. If a
+    # hook runs a `git+`-VCS pip install, the inherited GIT_INDEX_FILE
+    # causes pip's own `git checkout` (in its own throwaway clone) to write
+    # into the hook-invoking repo's index instead of its own, corrupting it.
+    # https://github.com/pypa/pip/issues/14290
+    unset_environ = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
     default_arg_rev = "HEAD"
 
     @staticmethod

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -93,6 +93,39 @@ def test_git_work_tree_ignored(tmpdir: pathlib.Path) -> None:
     Git.run_command(["status", repo_dir], extra_environ=env, cwd=repo_dir)
 
 
+def test_git_index_file_ignored(tmpdir: pathlib.Path) -> None:
+    """
+    Test that a GIT_INDEX_FILE environment variable is ignored.
+
+    Regression test for https://github.com/pypa/pip/issues/14290: git
+    itself sets GIT_INDEX_FILE when invoking hooks. If pip's git
+    subprocesses inherited it, a `git+` VCS install run from within a hook
+    could end up writing into the hook-invoking repo's index instead of
+    its own, corrupting it.
+    """
+    victim_path = tmpdir / "victim-repo"
+    victim_path.mkdir()
+    victim_dir = str(victim_path)
+    Git.run_command(["init", victim_dir], cwd=victim_dir)
+    victim_index = victim_path / ".git" / "index"
+    (victim_path / "tracked.txt").write_text("original")
+    Git.run_command(["add", "tracked.txt"], cwd=victim_dir)
+    before = victim_index.read_bytes()
+
+    work_path = tmpdir / "work-repo"
+    work_path.mkdir()
+    work_dir = str(work_path)
+    Git.run_command(["init", work_dir], cwd=work_dir)
+    (work_path / "new.txt").write_text("new")
+
+    env = {"GIT_INDEX_FILE": str(victim_index)}
+    # If GIT_INDEX_FILE is not ignored, this staging happens in the victim
+    # repo's index instead of the work repo's own index.
+    Git.run_command(["add", "new.txt"], cwd=work_dir, extra_environ=env)
+
+    assert victim_index.read_bytes() == before
+
+
 def test_get_remote_url(script: PipTestEnvironment, tmpdir: pathlib.Path) -> None:
     source_path = tmpdir / "source"
     source_path.mkdir()


### PR DESCRIPTION
Fixes #14290

### What

`Git.unset_environ` in `pip/_internal/vcs/git.py` already strips `GIT_DIR` and `GIT_WORK_TREE` from git subprocesses spawned for `git+` VCS installs (#1130), but not `GIT_INDEX_FILE`. This PR adds it.

### Why

`git` sets `GIT_INDEX_FILE` when invoking hooks (e.g. `pre-commit`), pointing at the index of the repo/worktree currently being committed. If such a hook runs a `git+`-pinned `pip install` (directly, or via a tool like `pip-audit`), the inherited `GIT_INDEX_FILE` causes pip's own `git checkout` — run inside its throwaway temp clone of the dependency — to write its checked-out tree into the **hook-invoking repo's index** instead of its own. Those entries reference blobs that only ever existed in the temp clone (deleted right after pip finishes), so `git fsck`/`git diff --staged` in the caller's repo comes back with `missing blob` / `invalid sha1 pointer in cache-tree` errors. This is fully deterministic — one `git commit` is enough, no concurrency needed. Repro steps and more detail are in #14290.

### Testing

Added `test_git_index_file_ignored`, mirroring the existing `test_git_dir_ignored` / `test_git_work_tree_ignored` pattern: stages a file in a "work" repo with `GIT_INDEX_FILE` pointed at a separate "victim" repo's index, and asserts the victim index is untouched.

- Confirmed this test fails without the fix (the victim index gets mutated) and passes with it.
- `ruff check` and `ruff format --check` clean on both changed files.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
