### PR TITLE
Don't log looking-at-multiple-versions on the first rejected candidate

### DIFF
--- a/news/12928.bugfix.rst
+++ b/news/12928.bugfix.rst
@@ -1,0 +1,1 @@
+Delay the multiple-versions message until a second candidate is rejected.

--- a/news/12928.bugfix.rst
+++ b/news/12928.bugfix.rst
@@ -1,1 +1,1 @@
-Delay the multiple-versions message until a second candidate is rejected.
+No longer log the "pip is looking at multiple versions of a package" message until pip has looked at at least two versions of that package.

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -17,8 +17,9 @@ class PipReporter(BaseReporter[Requirement, Candidate, str]):
         self.reject_count_by_package: defaultdict[str, int] = defaultdict(int)
         self._constraints = constraints or {}
 
+        # Only true after a second candidate of this package is rejected.
         self._messages_at_reject_count = {
-            1: (
+            2: (
                 "pip is looking at multiple versions of {package_name} to "
                 "determine which version is compatible with other "
                 "requirements. This could take a while."

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1236,9 +1236,13 @@ def test_new_resolver_presents_messages_when_backtracking_a_lot(
     )
 
     script.assert_installed(A="1.0.0", B="1.0.0", C="1.0.0")
-    # These numbers are hard-coded in the code.
-    if N >= 1:
+    # These numbers are hard-coded in PipReporter._messages_at_reject_count.
+    # N versions of A means N-1 rejections before 1.0.0 is selected; the
+    # first message is emitted on the 2nd rejection of a package.
+    if N >= 3:
         assert "This could take a while." in result.stdout
+    else:
+        assert "This could take a while." not in result.stdout
     if N >= 8:
         assert result.stdout.count("This could take a while.") >= 2
     if N >= 13:

--- a/tests/unit/resolution_resolvelib/test_reporter.py
+++ b/tests/unit/resolution_resolvelib/test_reporter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from pip._internal.resolution.resolvelib.reporter import PipReporter
+
+
+def _criterion() -> Mock:
+    criterion = Mock()
+    criterion.information = []
+    return criterion
+
+
+def _candidate(name: str = "django") -> Mock:
+    candidate = Mock()
+    candidate.name = name
+    return candidate
+
+
+def test_no_multiple_versions_message_on_first_rejection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO)
+    reporter = PipReporter()
+    reporter.rejecting_candidate(_criterion(), _candidate())
+    assert "looking at multiple versions" not in caplog.text
+
+
+def test_multiple_versions_message_on_second_rejection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO)
+    reporter = PipReporter()
+    reporter.rejecting_candidate(_criterion(), _candidate())
+    reporter.rejecting_candidate(_criterion(), _candidate())
+    assert "looking at multiple versions of django" in caplog.text


### PR DESCRIPTION
## What does this PR do?

Fixes #12928.

`PipReporter` currently logs "pip is looking at multiple versions of {package}" on the **first** rejected candidate. Installing a local wheel or a direct URL only has that one candidate, so the message is wrong — pip is not looking at other versions of the package.

Move that hint from reject-count 1 to 2. The later messages at 8 and 13 are unchanged.

Unit tests cover the first vs second rejection.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Grok