### PR TITLE
Do not run rustc or keyring from the current directory

### DIFF
--- a/news/14294.bugfix.rst
+++ b/news/14294.bugfix.rst
@@ -1,0 +1,2 @@
+Stop running a ``rustc`` or ``keyring`` executable found in the current
+directory when building the User-Agent or looking for a keyring backend.

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shutil
 import subprocess
 import sysconfig
 import typing
@@ -30,6 +29,7 @@ from pip._internal.utils.misc import (
     ask_password,
     remove_auth_from_url,
     split_auth_netloc_from_url,
+    which_outside_cwd,
 )
 from pip._internal.vcs.versioncontrol import AuthInfo
 
@@ -199,7 +199,7 @@ def get_keyring_provider(provider: str) -> KeyRingBaseProvider:
                 msg = msg + ", trying to find a keyring executable as a fallback"
             logger.warning(msg, exc, exc_info=logger.isEnabledFor(logging.DEBUG))
     if provider in ["subprocess", "auto"]:
-        cli = shutil.which("keyring")
+        cli = which_outside_cwd("keyring")
         if cli and cli.startswith(sysconfig.get_path("scripts")):
             # all code within this function is stolen from shutil.which implementation
             @typing.no_type_check
@@ -229,7 +229,7 @@ def get_keyring_provider(provider: str) -> KeyRingBaseProvider:
 
             path = os.pathsep.join(paths)
 
-            cli = shutil.which("keyring", path=path)
+            cli = which_outside_cwd("keyring", path=path)
 
         if cli:
             logger.verbose("Keyring provider set: subprocess with executable %s", cli)

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -13,7 +13,6 @@ import logging
 import mimetypes
 import os
 import platform
-import shutil
 import subprocess
 import sys
 import urllib.parse
@@ -49,6 +48,7 @@ from pip._internal.utils.misc import (
     looks_like_ci,
     parse_netloc,
     redact_auth_from_url,
+    which_outside_cwd,
 )
 from pip._internal.utils.urls import url_to_path
 
@@ -151,11 +151,12 @@ def user_agent() -> str:
     if setuptools_dist is not None:
         data["setuptools_version"] = str(setuptools_dist.version)
 
-    if shutil.which("rustc") is not None:
+    rustc_path = which_outside_cwd("rustc")
+    if rustc_path is not None:
         # If for any reason `rustc --version` fails, silently ignore it
         try:
             rustc_output = subprocess.check_output(
-                ["rustc", "--version"], stderr=subprocess.STDOUT, timeout=0.5
+                [rustc_path, "--version"], stderr=subprocess.STDOUT, timeout=0.5
             )
         except Exception:
             pass

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -52,6 +52,7 @@ __all__ = [
     "format_size",
     "is_installable_dir",
     "normalize_path",
+    "which_outside_cwd",
     "renames",
     "get_prog",
     "ensure_dir",
@@ -368,6 +369,30 @@ def normalize_path(path: str, resolve_symlinks: bool = True) -> str:
     else:
         path = os.path.abspath(path)
     return os.path.normcase(path)
+
+
+def which_outside_cwd(cmd: str, path: str | None = None) -> str | None:
+    """Like ``shutil.which()``, but skips the implicit cwd search Windows does.
+
+    The result is absolute, so running it does not look it up a second time.
+    """
+    found = shutil.which(cmd, path=path)
+    if found is None:
+        return None
+    try:
+        found = os.path.abspath(found)
+        cwd = os.getcwd()
+        if os.path.normcase(os.path.dirname(found)) != os.path.normcase(cwd):
+            return found
+        search_path = os.environ.get("PATH", os.defpath) if path is None else path
+        on_path = any(
+            os.path.normcase(os.path.abspath(entry)) == os.path.normcase(cwd)
+            for entry in search_path.split(os.pathsep)
+        )
+    except OSError:
+        # The current directory is gone, so nothing can have been found in it.
+        return found
+    return found if on_path else None
 
 
 def splitext(path: str) -> tuple[str, str]:

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -595,7 +595,11 @@ def test_keyring_cli_get_password(
     expect: tuple[str | None, str | None],
 ) -> None:
     keyring_subprocess = KeyringSubprocessResult()
-    monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
+    monkeypatch.setattr(
+        pip._internal.network.auth,
+        "which_outside_cwd",
+        lambda cmd, path=None: "keyring",
+    )
     monkeypatch.setattr(
         pip._internal.network.auth.subprocess, "run", keyring_subprocess
     )
@@ -615,6 +619,20 @@ def test_keyring_cli_get_password(
     ):
         actual = auth._get_new_credentials(url, allow_netrc=False, allow_keyring=True)
         assert actual == expect
+
+
+def test_keyring_cli_not_taken_from_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A keyring executable that only resolves inside the current directory must
+    # not become the subprocess provider (pypa/pip#14294).
+    monkeypatch.setattr(
+        pip._internal.network.auth,
+        "which_outside_cwd",
+        lambda cmd, path=None: None,
+    )
+
+    provider = pip._internal.network.auth.get_keyring_provider("subprocess")
+
+    assert isinstance(provider, pip._internal.network.auth.KeyRingNullProvider)
 
 
 @pytest.mark.parametrize(
@@ -640,7 +658,11 @@ def test_keyring_cli_set_password(
     expect_save: bool,
 ) -> None:
     expected_username, expected_password, save = creds
-    monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
+    monkeypatch.setattr(
+        pip._internal.network.auth,
+        "which_outside_cwd",
+        lambda cmd, path=None: "keyring",
+    )
     keyring = KeyringSubprocessResult()
     monkeypatch.setattr(pip._internal.network.auth.subprocess, "run", keyring)
     auth = MultiDomainBasicAuth(prompting=True, keyring_provider="subprocess")
@@ -716,7 +738,11 @@ def test_keyring_cli_outdated_version(
     keyring_subprocess = KeyringSubprocessResult()
     keyring_subprocess.old_version = True
 
-    monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
+    monkeypatch.setattr(
+        pip._internal.network.auth,
+        "which_outside_cwd",
+        lambda cmd, path=None: "keyring",
+    )
     monkeypatch.setattr(
         pip._internal.network.auth.subprocess, "run", keyring_subprocess
     )

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -157,6 +157,51 @@ def test_user_agent_user_data(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "some_string" in get_user_agent()
 
 
+def _spy_rustc_check_output(
+    monkeypatch: pytest.MonkeyPatch, calls: list[list[str]]
+) -> Any:
+    # Record only rustc invocations and return canned output for them; delegate
+    # everything else (e.g. distro's lsb_release probe) to the real
+    # subprocess.check_output so the tests do not depend on call ordering.
+    from pip._internal.network import session
+
+    real_check_output = session.subprocess.check_output
+
+    def spy(cmd: Any, *args: Any, **kwargs: Any) -> bytes:
+        if cmd and os.path.basename(str(cmd[0])) == "rustc":
+            calls.append(list(cmd))
+            return b"rustc 1.52.1 (9bc8c42bb 2021-05-09)\n"
+        return real_check_output(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(session.subprocess, "check_output", spy)
+    return session
+
+
+def test_user_agent_rustc_not_probed_when_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    session = _spy_rustc_check_output(monkeypatch, calls)
+    monkeypatch.setattr(session, "which_outside_cwd", lambda cmd: None)
+
+    user_agent = get_user_agent()
+    assert calls == []
+    assert "rustc_version" not in user_agent
+
+
+def test_user_agent_rustc_probed_by_resolved_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+    session = _spy_rustc_check_output(monkeypatch, calls)
+    rustc = str(tmp_path / "rustc")
+    monkeypatch.setattr(session, "which_outside_cwd", lambda cmd: rustc)
+
+    user_agent = get_user_agent()
+    assert calls == [[rustc, "--version"]]
+    assert '"rustc_version":"1.52.1"' in user_agent
+
+
 class TestPipSession:
     def test_cache_defaults_off(self) -> None:
         session = PipSession()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -51,6 +51,7 @@ from pip._internal.utils.misc import (
     split_auth_from_netloc,
     split_auth_netloc_from_url,
     tabulate,
+    which_outside_cwd,
 )
 
 
@@ -389,6 +390,55 @@ class Test_normalize_path:
             )
         finally:
             os.chdir(orig_working_dir)
+
+
+def test_which_outside_cwd_returns_absolute_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    rustc = str(tmp_path / "rustc")
+    monkeypatch.setattr(shutil, "which", lambda cmd, path=None: rustc)
+
+    assert which_outside_cwd("rustc") == rustc
+
+
+def test_which_outside_cwd_ignores_implicit_match_in_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # What shutil.which() returns on Windows for a hit in the cwd.
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd, path=None: os.path.join(os.curdir, "rustc")
+    )
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert which_outside_cwd("rustc") is None
+
+
+def test_which_outside_cwd_keeps_match_when_cwd_is_on_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An explicit PATH entry for the cwd is the user asking for this.
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd, path=None: os.path.join(os.curdir, "rustc")
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([os.curdir, "/usr/bin"]))
+
+    assert which_outside_cwd("rustc") == os.path.join(os.getcwd(), "rustc")
+
+
+def test_which_outside_cwd_tolerates_missing_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Callers use this for optional probes, so a current directory that has
+    # been removed out from under pip must not turn one into a crash.
+    rustc = str(tmp_path / "rustc")
+    monkeypatch.setattr(shutil, "which", lambda cmd, path=None: rustc)
+
+    def no_cwd() -> str:
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(os, "getcwd", no_cwd)
+
+    assert which_outside_cwd("rustc") == rustc
 
 
 class TestHashes:


### PR DESCRIPTION
On Windows shutil.which() and CreateProcess() search the current directory ahead of PATH, so a planted rustc.exe or keyring.exe wins over the real one.

Route both lookups through which_outside_cwd(), which drops a match in the cwd and returns an absolute path.


## What does this PR do?

Fixes: #14294 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [X] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [X] I have added a news file fragment (or this PR does not need one).
- [X] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

I've used Claude to help me identify the issue and test it on a Windows 11 VM to verify, along with testing the fix. It was also used to review my fixes.