### PR TITLE
Restore command log level in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
     "pytest-subket",
     "scripttest",
     "setuptools",
-    "virtualenv >= 20.0",
+    "virtualenv >= 20.0.28",
     "werkzeug",
     "tomli-w",
     "proxy.py",

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -1,6 +1,7 @@
 """Test the test support."""
 
 import filecmp
+import logging
 import pathlib
 import re
 import sys
@@ -18,6 +19,7 @@ from tests.lib import (
     create_basic_wheel_for_package,
     create_test_package_with_setup,
 )
+from tests.lib.venv import VirtualEnvironment
 
 
 @contextmanager
@@ -31,6 +33,19 @@ def assert_error_startswith(
         yield
 
     assert str(err.value).startswith(expected_start), f"full message: {err.value}"
+
+
+def test_virtualenv_creation_preserves_logging(tmp_path: pathlib.Path) -> None:
+    logger = logging.getLogger()
+    level = logger.level
+    handlers = logger.handlers[:]
+    try:
+        VirtualEnvironment(tmp_path / "venv")
+        assert logger.level == level
+        assert logger.handlers == handlers
+    finally:
+        logger.setLevel(level)
+        logger.handlers[:] = handlers
 
 
 def test_tmp_dir_exists_in_env(script: PipTestEnvironment) -> None:

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -73,6 +73,7 @@ class VirtualEnvironment:
                         "--no-setuptools",
                         os.fspath(self.location),
                     ],
+                    setup_logging=False,
                 )
             elif self._venv_type == "venv":
                 builder = _venv.EnvBuilder()

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -26,6 +26,15 @@ from pip._internal.utils.logging import BrokenStdoutLoggingError
 from pip._internal.utils.temp_dir import TempDirectory
 
 
+@pytest.fixture(autouse=True)
+def restore_logging_level() -> Iterator[None]:
+    """Restore the root level after a command configures logging."""
+    logger = logging.getLogger()
+    level = logger.level
+    yield
+    logger.setLevel(level)
+
+
 @pytest.fixture
 def fixed_time() -> Iterator[None]:
     # Patch time so logs contain a constant timestamp. time.time_ns is used by


### PR DESCRIPTION
Running pip tests locally, verbose command tests and virtualenv's setup can leave the root logger accepting debug messages, making keyring warnings tests that come afterward fail on extra records.

This restores the root level after command tests, and tells virtualenv to keep the existing logging configuration, it requires virtualenv 20.0.28, which introduced a logging setup option.