### PR TITLE
Explicitly set the level of captured logging in test_keyring_cli_outdated_version

### DIFF
--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -4,6 +4,7 @@ import base64
 import contextlib
 import functools
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -713,6 +714,8 @@ def test_keyring_cli_outdated_version(
     url: str,
     expect: tuple[str | None, str | None],
 ) -> None:
+    caplog.set_level(logging.INFO)
+
     keyring_subprocess = KeyringSubprocessResult()
     keyring_subprocess.old_version = True
 


### PR DESCRIPTION
## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->


When updating pip from 26.1.2 to 26.2.1 in Fedora, we realized that the test_keyring_cli_outdated_version test is flaky. This is not necessarily new in 26.2.1, we just noticed it now.

Often 1 or more of the parametrized runs fail with:

    AssertionError: assert 7 == 1

This is caused by VERBOSE and DEBUG log messages:

    ------------------------------ Captured log call -------------------------------
    DEBUG    pip._internal.network.auth:auth.py:381 Found index url http://example.com/path2/
    VERBOSE  pip._internal.network.auth:_log.py:23 Keyring provider requested: subprocess
    VERBOSE  pip._internal.network.auth:_log.py:23 Keyring provider set: subprocess with executable keyring
    DEBUG    pip._internal.network.auth:auth.py:294 Keyring is skipped due to an exception
    Traceback (most recent call last):
      File ".../usr/lib/python3.15/site-packages/pip/_internal/network/auth.py", line 290, in _get_keyring_auth
        return self.keyring_provider.get_auth_info(url, username)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File ".../usr/lib/python3.15/site-packages/pip/_internal/network/auth.py", line 122, in get_auth_info
        return self._get_creds(url, username)
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File ".../usr/lib/python3.15/site-packages/pip/_internal/network/auth.py", line 154, in _get_creds
        raise RuntimeError(
        ...<2 lines>...
        )
    RuntimeError: Keyring util is outdated; must be at least version 25.2.1, please upgrade it
    WARNING  pip._internal.network.auth:auth.py:296 Keyring is skipped due to an exception: Keyring util is outdated; must be at least version 25.2.1, please upgrade it
    VERBOSE  pip._internal.network.auth:_log.py:23 Keyring provider requested: subprocess
    VERBOSE  pip._internal.network.auth:_log.py:23 Keyring provider set: disabled

We run the test suite with pytest-xdist and it seems to me that other tests are manipulating the log level,
and the flakiness depends on which worker runs which tests.

Set the log level explicitly to make the assumptions of the test more sane.

<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

- I have not used AI tools here, and it felt good.
- I believe this does not need a news fragment.
