### PR TITLE
Upgrade platformdirs to 4.11.12

### DIFF
--- a/news/14303.bugfix.rst
+++ b/news/14303.bugfix.rst
@@ -1,0 +1,3 @@
+Fix pip using the wrong global config location on macOS when running inside a
+virtual environment created from a Homebrew Python installation, by upgrading
+the vendored ``platformdirs`` to 4.11.8.

--- a/news/platformdirs.vendor.rst
+++ b/news/platformdirs.vendor.rst
@@ -1,1 +1,1 @@
-Upgrade platformdirs to 4.11.0
+Upgrade platformdirs to 4.11.8

--- a/src/pip/_vendor/bom.cdx.json
+++ b/src/pip/_vendor/bom.cdx.json
@@ -57,11 +57,11 @@
       "version": "26.3"
     },
     {
-      "bom-ref": "pkg:pypi/platformdirs@4.11.0",
+      "bom-ref": "pkg:pypi/platformdirs@4.11.8",
       "name": "platformdirs",
-      "purl": "pkg:pypi/platformdirs@4.11.0",
+      "purl": "pkg:pypi/platformdirs@4.11.8",
       "type": "library",
-      "version": "4.11.0"
+      "version": "4.11.8"
     },
     {
       "bom-ref": "pkg:pypi/pygments@2.20.0",
@@ -144,7 +144,7 @@
         "pkg:pypi/idna@3.18",
         "pkg:pypi/msgpack@1.2.1",
         "pkg:pypi/packaging@26.3",
-        "pkg:pypi/platformdirs@4.11.0",
+        "pkg:pypi/platformdirs@4.11.8",
         "pkg:pypi/pygments@2.20.0",
         "pkg:pypi/pyproject-hooks@1.2.0",
         "pkg:pypi/requests@2.34.2",
@@ -180,7 +180,7 @@
       "ref": "pkg:pypi/packaging@26.3"
     },
     {
-      "ref": "pkg:pypi/platformdirs@4.11.0"
+      "ref": "pkg:pypi/platformdirs@4.11.8"
     },
     {
       "ref": "pkg:pypi/pygments@2.20.0"

--- a/src/pip/_vendor/platformdirs/__init__.py
+++ b/src/pip/_vendor/platformdirs/__init__.py
@@ -364,14 +364,42 @@ def user_fonts_dir() -> str:
     return PlatformDirs().user_fonts_dir
 
 
-def user_preference_dir() -> str:
-    """:returns: preference directory tied to the user"""
-    return PlatformDirs().user_preference_dir
+def user_preference_dir(  # ruff:ignore[too-many-arguments]
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    *,
+    roaming: bool = False,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
+) -> str:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: preference directory tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_preference_dir
 
 
-def user_bin_dir() -> str:
-    """:returns: bin directory tied to the user"""
-    return PlatformDirs().user_bin_dir
+def user_bin_dir(*, use_site_for_root: bool = False) -> str:
+    """:param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: bin directory tied to the user
+
+    """
+    return PlatformDirs(use_site_for_root=use_site_for_root).user_bin_dir
 
 
 def site_bin_dir() -> str:
@@ -379,22 +407,53 @@ def site_bin_dir() -> str:
     return PlatformDirs().site_bin_dir
 
 
-def user_applications_dir() -> str:
-    """:returns: applications directory tied to the user"""
-    return PlatformDirs().user_applications_dir
+def user_applications_dir(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    *,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
+) -> str:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: applications directory tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_applications_dir
 
 
 def site_applications_dir(
     multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
     ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
 ) -> str:
     """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
 
     :returns: applications directory shared by users
 
     """
     return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
         multipath=multipath,
         ensure_exists=ensure_exists,
     ).site_applications_dir
@@ -765,14 +824,42 @@ def user_fonts_path() -> Path:
     return PlatformDirs().user_fonts_path
 
 
-def user_preference_path() -> Path:
-    """:returns: preference path tied to the user"""
-    return PlatformDirs().user_preference_path
+def user_preference_path(  # ruff:ignore[too-many-arguments]
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    *,
+    roaming: bool = False,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
+) -> Path:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: preference path tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_preference_path
 
 
-def user_bin_path() -> Path:
-    """:returns: bin path tied to the user"""
-    return PlatformDirs().user_bin_path
+def user_bin_path(*, use_site_for_root: bool = False) -> Path:
+    """:param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: bin path tied to the user
+
+    """
+    return PlatformDirs(use_site_for_root=use_site_for_root).user_bin_path
 
 
 def site_bin_path() -> Path:
@@ -780,22 +867,53 @@ def site_bin_path() -> Path:
     return PlatformDirs().site_bin_path
 
 
-def user_applications_path() -> Path:
-    """:returns: applications path tied to the user"""
-    return PlatformDirs().user_applications_path
+def user_applications_path(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    *,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
+) -> Path:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: applications path tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_applications_path
 
 
 def site_applications_path(
     multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
     ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
 ) -> Path:
     """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
 
     :returns: applications path shared by users
 
     """
     return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
         multipath=multipath,
         ensure_exists=ensure_exists,
     ).site_applications_path

--- a/src/pip/_vendor/platformdirs/__main__.py
+++ b/src/pip/_vendor/platformdirs/__main__.py
@@ -15,6 +15,7 @@ PROPS = (
     "user_pictures_dir",
     "user_videos_dir",
     "user_music_dir",
+    "user_desktop_dir",
     "user_projects_dir",
     "user_publicshare_dir",
     "user_templates_dir",

--- a/src/pip/_vendor/platformdirs/_xdg.py
+++ b/src/pip/_vendor/platformdirs/_xdg.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import posixpath
+from typing import Final
 
 from .api import PlatformDirsABC
 
@@ -13,14 +15,14 @@ class XDGMixin(PlatformDirsABC):
     @property
     def user_data_dir(self) -> str:
         """Data directory tied to the user, from ``$XDG_DATA_HOME`` if set, else platform default."""
-        if path := os.environ.get("XDG_DATA_HOME", "").strip():
+        if path := _xdg_dir("XDG_DATA_HOME"):
             return self._append_app_name_and_version(path)
         return super().user_data_dir
 
     @property
     def _site_data_dirs(self) -> list[str]:
-        if xdg_dirs := os.environ.get("XDG_DATA_DIRS", "").strip():
-            return [self._append_app_name_and_version(p) for p in xdg_dirs.split(os.pathsep) if p.strip()]
+        if xdg_dirs := _xdg_dir_list("XDG_DATA_DIRS"):
+            return [self._append_app_name_and_version(p) for p in xdg_dirs]
         return super()._site_data_dirs
 
     @property
@@ -32,14 +34,14 @@ class XDGMixin(PlatformDirsABC):
     @property
     def user_config_dir(self) -> str:
         """Config directory tied to the user, from ``$XDG_CONFIG_HOME`` if set, else platform default."""
-        if path := os.environ.get("XDG_CONFIG_HOME", "").strip():
+        if path := _xdg_dir("XDG_CONFIG_HOME"):
             return self._append_app_name_and_version(path)
         return super().user_config_dir
 
     @property
     def _site_config_dirs(self) -> list[str]:
-        if xdg_dirs := os.environ.get("XDG_CONFIG_DIRS", "").strip():
-            return [self._append_app_name_and_version(p) for p in xdg_dirs.split(os.pathsep) if p.strip()]
+        if xdg_dirs := _xdg_dir_list("XDG_CONFIG_DIRS"):
+            return [self._append_app_name_and_version(p) for p in xdg_dirs]
         return super()._site_config_dirs
 
     @property
@@ -51,28 +53,28 @@ class XDGMixin(PlatformDirsABC):
     @property
     def user_cache_dir(self) -> str:
         """Cache directory tied to the user, from ``$XDG_CACHE_HOME`` if set, else platform default."""
-        if path := os.environ.get("XDG_CACHE_HOME", "").strip():
+        if path := _xdg_dir("XDG_CACHE_HOME"):
             return self._append_app_name_and_version(path)
         return super().user_cache_dir
 
     @property
     def user_state_dir(self) -> str:
         """State directory tied to the user, from ``$XDG_STATE_HOME`` if set, else platform default."""
-        if path := os.environ.get("XDG_STATE_HOME", "").strip():
+        if path := _xdg_dir("XDG_STATE_HOME"):
             return self._append_app_name_and_version(path)
         return super().user_state_dir
 
     @property
     def user_runtime_dir(self) -> str:
         """Runtime directory tied to the user, from ``$XDG_RUNTIME_DIR`` if set, else platform default."""
-        if path := os.environ.get("XDG_RUNTIME_DIR", "").strip():
+        if path := _xdg_dir("XDG_RUNTIME_DIR"):
             return self._append_app_name_and_version(path)
         return super().user_runtime_dir
 
     @property
     def site_runtime_dir(self) -> str:
         """Runtime directory shared by users, from ``$XDG_RUNTIME_DIR`` if set, else platform default."""
-        if path := os.environ.get("XDG_RUNTIME_DIR", "").strip():
+        if path := _xdg_dir("XDG_RUNTIME_DIR"):
             return self._append_app_name_and_version(path)
         return super().site_runtime_dir
 
@@ -142,21 +144,21 @@ class XDGMixin(PlatformDirsABC):
     @property
     def user_fonts_dir(self) -> str:
         """Fonts directory tied to the user, from ``$XDG_DATA_HOME/fonts`` if set, else platform default."""
-        if path := os.environ.get("XDG_DATA_HOME", "").strip():
+        if path := _xdg_dir("XDG_DATA_HOME"):
             return f"{os.path.expanduser(path)}/fonts"  # ruff:ignore[os-path-expanduser]  # API returns str, not Path
         return super().user_fonts_dir
 
     @property
     def user_applications_dir(self) -> str:
         """Applications directory tied to the user, from ``$XDG_DATA_HOME`` if set, else platform default."""
-        if path := os.environ.get("XDG_DATA_HOME", "").strip():
+        if path := _xdg_dir("XDG_DATA_HOME"):
             return os.path.join(os.path.expanduser(path), "applications")  # ruff:ignore[os-path-expanduser, os-path-join]
         return super().user_applications_dir
 
     @property
     def _site_applications_dirs(self) -> list[str]:
-        if xdg_dirs := os.environ.get("XDG_DATA_DIRS", "").strip():
-            return [os.path.join(p, "applications") for p in xdg_dirs.split(os.pathsep) if p.strip()]  # ruff:ignore[os-path-join]
+        if xdg_dirs := _xdg_dir_list("XDG_DATA_DIRS"):
+            return [os.path.join(p, "applications") for p in xdg_dirs]  # ruff:ignore[os-path-join]
         return super()._site_applications_dirs
 
     @property
@@ -166,6 +168,18 @@ class XDGMixin(PlatformDirsABC):
         return os.pathsep.join(dirs) if self.multipath else dirs[0]
 
 
+def _xdg_dir(env_var: str) -> str | None:
+    path: Final = os.environ.get(env_var, "").strip()
+    return path if posixpath.isabs(path) else None
+
+
+def _xdg_dir_list(env_var: str) -> list[str]:
+    return [
+        stripped for path in os.environ.get(env_var, "").split(os.pathsep) if posixpath.isabs(stripped := path.strip())
+    ]
+
+
 __all__ = [
     "XDGMixin",
+    "_xdg_dir",
 ]

--- a/src/pip/_vendor/platformdirs/api.py
+++ b/src/pip/_vendor/platformdirs/api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from typing import Literal
 
 
@@ -389,8 +389,8 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
 
     @property
     def site_applications_path(self) -> Path:
-        """Applications path shared by users."""
-        return Path(self.site_applications_dir)
+        """Applications path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
+        return self._first_item_as_path_if_multipath(self.site_applications_dir)
 
     @property
     def user_runtime_path(self) -> Path:
@@ -404,31 +404,49 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
 
     def iter_config_dirs(self) -> Iterator[str]:
         """:yield: all user and site configuration directories."""
+        yield from _unique(self._iter_config_dirs())
+
+    def _iter_config_dirs(self) -> Iterator[str]:
         yield self.user_config_dir
         yield self.site_config_dir
 
     def iter_data_dirs(self) -> Iterator[str]:
         """:yield: all user and site data directories."""
+        yield from _unique(self._iter_data_dirs())
+
+    def _iter_data_dirs(self) -> Iterator[str]:
         yield self.user_data_dir
         yield self.site_data_dir
 
     def iter_cache_dirs(self) -> Iterator[str]:
         """:yield: all user and site cache directories."""
+        yield from _unique(self._iter_cache_dirs())
+
+    def _iter_cache_dirs(self) -> Iterator[str]:
         yield self.user_cache_dir
         yield self.site_cache_dir
 
     def iter_state_dirs(self) -> Iterator[str]:
         """:yield: all user and site state directories."""
+        yield from _unique(self._iter_state_dirs())
+
+    def _iter_state_dirs(self) -> Iterator[str]:
         yield self.user_state_dir
         yield self.site_state_dir
 
     def iter_log_dirs(self) -> Iterator[str]:
         """:yield: all user and site log directories."""
+        yield from _unique(self._iter_log_dirs())
+
+    def _iter_log_dirs(self) -> Iterator[str]:
         yield self.user_log_dir
         yield self.site_log_dir
 
     def iter_runtime_dirs(self) -> Iterator[str]:
         """:yield: all user and site runtime directories."""
+        yield from _unique(self._iter_runtime_dirs())
+
+    def _iter_runtime_dirs(self) -> Iterator[str]:
         yield self.user_runtime_dir
         yield self.site_runtime_dir
 
@@ -461,3 +479,14 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
         """:yield: all user and site runtime paths."""
         for path in self.iter_runtime_dirs():
             yield Path(path)
+
+
+def _unique(dirs: Iterable[str]) -> Iterator[str]:
+    """:yield: ``dirs`` in order, skipping any directory already yielded."""
+    # Lazy on purpose: under ensure_exists reading a site_*_dir creates it, so draining ``dirs`` up front would
+    # create directories for a caller that stops after the first entry.
+    seen: set[str] = set()
+    for path in dirs:
+        if path not in seen:
+            seen.add(path)
+            yield path

--- a/src/pip/_vendor/platformdirs/macos.py
+++ b/src/pip/_vendor/platformdirs/macos.py
@@ -29,8 +29,8 @@ class _MacOSDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         return self._append_app_name_and_version(os.path.expanduser("~/Library/Application Support"))  # ruff:ignore[os-path-expanduser]
 
     def _base_site_dirs(self) -> list[str]:
-        is_homebrew = "/opt/python" in sys.prefix
-        homebrew_prefix = sys.prefix.split("/opt/python")[0] if is_homebrew else ""
+        is_homebrew = "/opt/python" in sys.base_prefix
+        homebrew_prefix = sys.base_prefix.split("/opt/python")[0] if is_homebrew else ""
         path_list = [self._append_app_name_and_version(f"{homebrew_prefix}/share")] if is_homebrew else []
         path_list.append(self._append_app_name_and_version("/Library/Application Support"))
         return path_list
@@ -69,15 +69,18 @@ class _MacOSDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         return self._append_app_name_and_version(os.path.expanduser("~/Library/Caches"))  # ruff:ignore[os-path-expanduser]
 
     @property
-    def site_cache_dir(self) -> str:
-        """Cache directory shared by users, e.g. ``/Library/Caches/$appname/$version``. If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory will be under the Homebrew prefix, e.g. ``$homebrew_prefix/var/cache/$appname/$version``. If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled, and we're in Homebrew, the response is a multi-path string separated by ":", e.g. ``$homebrew_prefix/var/cache/$appname/$version:/Library/Caches/$appname/$version``."""
-        is_homebrew = "/opt/python" in sys.prefix
-        homebrew_prefix = sys.prefix.split("/opt/python")[0] if is_homebrew else ""
+    def _site_cache_dirs(self) -> list[str]:
+        is_homebrew = "/opt/python" in sys.base_prefix
+        homebrew_prefix = sys.base_prefix.split("/opt/python")[0] if is_homebrew else ""
         path_list = [self._append_app_name_and_version(f"{homebrew_prefix}/var/cache")] if is_homebrew else []
         path_list.append(self._append_app_name_and_version("/Library/Caches"))
-        if self.multipath:
-            return os.pathsep.join(path_list)
-        return path_list[0]
+        return path_list
+
+    @property
+    def site_cache_dir(self) -> str:
+        """Cache directory shared by users, e.g. ``/Library/Caches/$appname/$version``. If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory will be under the Homebrew prefix, e.g. ``$homebrew_prefix/var/cache/$appname/$version``. If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled, and we're in Homebrew, the response is a multi-path string separated by ":", e.g. ``$homebrew_prefix/var/cache/$appname/$version:/Library/Caches/$appname/$version``."""
+        dirs = self._site_cache_dirs
+        return os.pathsep.join(dirs) if self.multipath else dirs[0]
 
     @property
     def site_cache_path(self) -> Path:
@@ -194,15 +197,17 @@ class _MacOSDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Runtime directory shared by users, same as `user_runtime_dir`."""
         return self.user_runtime_dir
 
-    def iter_config_dirs(self) -> Iterator[str]:
-        """:yield: all user and site configuration directories."""
+    def _iter_config_dirs(self) -> Iterator[str]:
         yield self.user_config_dir
         yield from self._site_config_dirs
 
-    def iter_data_dirs(self) -> Iterator[str]:
-        """:yield: all user and site data directories."""
+    def _iter_data_dirs(self) -> Iterator[str]:
         yield self.user_data_dir
         yield from self._site_data_dirs
+
+    def _iter_cache_dirs(self) -> Iterator[str]:
+        yield self.user_cache_dir
+        yield from self._site_cache_dirs
 
 
 class MacOS(XDGMixin, _MacOSDefaults):

--- a/src/pip/_vendor/platformdirs/unix.py
+++ b/src/pip/_vendor/platformdirs/unix.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from tempfile import gettempdir
 from typing import TYPE_CHECKING, NoReturn
 
-from ._xdg import XDGMixin
+from ._xdg import XDGMixin, _xdg_dir
 from .api import PlatformDirsABC
 
 if TYPE_CHECKING:
@@ -226,17 +226,37 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
-    def iter_config_dirs(self) -> Iterator[str]:
-        """:yield: all user and site configuration directories."""
+    def _iter_config_dirs(self) -> Iterator[str]:
+        # Under multipath the user dir is an os.pathsep-joined string that no single site entry matches, so the
+        # dedupe in iter_config_dirs cannot drop it. Skip it here instead.
         if not self._use_site:
             yield self.user_config_dir
         yield from self._site_config_dirs
 
-    def iter_data_dirs(self) -> Iterator[str]:
-        """:yield: all user and site data directories."""
+    def _iter_data_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_data_dir
         yield from self._site_data_dirs
+
+    def _iter_cache_dirs(self) -> Iterator[str]:
+        if not self._use_site:
+            yield self.user_cache_dir
+        yield self.site_cache_dir
+
+    def _iter_state_dirs(self) -> Iterator[str]:
+        if not self._use_site:
+            yield self.user_state_dir
+        yield self.site_state_dir
+
+    def _iter_log_dirs(self) -> Iterator[str]:
+        if not self._use_site:
+            yield self.user_log_dir
+        yield self.site_log_dir
+
+    def _iter_runtime_dirs(self) -> Iterator[str]:
+        if not self._use_site:
+            yield self.user_runtime_dir
+        yield self.site_runtime_dir
 
 
 class Unix(XDGMixin, _UnixDefaults):
@@ -290,6 +310,26 @@ class Unix(XDGMixin, _UnixDefaults):
         """Bin directory tied to the user, or site equivalent when root with ``use_site_for_root``."""
         return self.site_bin_dir if self._use_site else super().user_bin_dir
 
+    @property
+    def user_data_path(self) -> Path:
+        """Data path tied to the user, or the first site entry when root with ``use_site_for_root``."""
+        return self.site_data_path if self._use_site else super().user_data_path
+
+    @property
+    def user_config_path(self) -> Path:
+        """Config path tied to the user, or the first site entry when root with ``use_site_for_root``."""
+        return self.site_config_path if self._use_site else super().user_config_path
+
+    @property
+    def user_preference_path(self) -> Path:
+        """Preference path tied to the user, or the first site config entry when root with ``use_site_for_root``."""
+        return self.site_config_path if self._use_site else super().user_preference_path
+
+    @property
+    def user_applications_path(self) -> Path:
+        """Applications path tied to the user, or the first site entry when root with ``use_site_for_root``."""
+        return self.site_applications_path if self._use_site else super().user_applications_path
+
 
 def _get_user_media_dir(env_var: str, fallback_tilde_path: str) -> str:
     if media_dir := _get_user_dirs_folder(env_var):
@@ -303,10 +343,10 @@ def _get_user_dirs_folder(key: str) -> str | None:
     See https://freedesktop.org/wiki/Software/xdg-user-dirs/.
 
     """
-    config_home = os.environ.get("XDG_CONFIG_HOME", "").strip() or os.path.expanduser("~/.config")  # ruff:ignore[os-path-expanduser]
+    config_home = _xdg_dir("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")  # ruff:ignore[os-path-expanduser]
     user_dirs_config_path = Path(config_home) / "user-dirs.dirs"
     if user_dirs_config_path.exists():
-        parser = ConfigParser()
+        parser = ConfigParser(interpolation=None)
 
         with user_dirs_config_path.open() as stream:
             parser.read_string(f"[top]\n{stream.read()}")

--- a/src/pip/_vendor/platformdirs/version.py
+++ b/src/pip/_vendor/platformdirs/version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '4.11.0'
-__version_tuple__ = version_tuple = (4, 11, 0)
+__version__ = version = '4.11.8'
+__version_tuple__ = version_tuple = (4, 11, 8)
 
 __commit_id__ = commit_id = None

--- a/src/pip/_vendor/platformdirs/windows.py
+++ b/src/pip/_vendor/platformdirs/windows.py
@@ -230,6 +230,9 @@ def get_win_folder_if_csidl_name_not_env_var(csidl_name: str) -> str | None:  # 
     if csidl_name == "CSIDL_MYMUSIC":
         return os.path.join(os.path.normpath(os.environ["USERPROFILE"]), "Music")  # ruff:ignore[os-path-join]
 
+    if csidl_name == "CSIDL_DESKTOPDIRECTORY":
+        return os.path.join(os.path.normpath(os.environ["USERPROFILE"]), "Desktop")  # ruff:ignore[os-path-join]
+
     if csidl_name == "CSIDL_PROGRAMS":
         return os.path.join(  # ruff:ignore[os-path-join]
             os.path.normpath(os.environ["APPDATA"]),
@@ -270,6 +273,7 @@ def get_win_folder_from_registry(csidl_name: str) -> str:
         "CSIDL_MYPICTURES": "My Pictures",
         "CSIDL_MYVIDEO": "My Video",
         "CSIDL_MYMUSIC": "My Music",
+        "CSIDL_DESKTOPDIRECTORY": "Desktop",
         "CSIDL_PROGRAMS": "Programs",
         "CSIDL_COMMON_PROGRAMS": "Common Programs",
     }.get(csidl_name)

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -3,7 +3,7 @@ distlib==0.4.3
 distro==1.9.0
 msgpack==1.2.1
 packaging==26.3
-platformdirs==4.11.0
+platformdirs==4.11.8
 pyproject-hooks==1.2.0
 requests==2.34.2
     certifi==2026.7.22

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -127,7 +127,7 @@ class TestSiteConfigDirs:
         python_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
         monkeypatch.setattr(
             sys,
-            "prefix",
+            "base_prefix",
             f"/opt/homebrew/opt/python@{python_version}/Frameworks/Python.framework/Versions/{python_version}",
         )
 


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->

Bumps the vendored `platformdirs` to 4.11.12 (4.11.8+ really) to fix a config dir location bug where `site_data_dir` would point to the wrong dir running inside a virtual environment createad from a Homebrew-managed Python, now fixed by preferring the base interpreter.

- https://github.com/tox-dev/platformdirs/pull/543 (shipped in 4.11.8)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->
