### PR TITLE
Ignore GIT_INDEX_FILE in Git subprocesses

### DIFF
--- a/news/14290.bugfix.rst
+++ b/news/14290.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore ``GIT_INDEX_FILE`` when invoking Git for VCS requirements.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -71,7 +71,7 @@ class Git(VersionControl):
     )
     # Prevent the user's environment variables from interfering with pip:
     # https://github.com/pypa/pip/issues/1130
-    unset_environ = ("GIT_DIR", "GIT_WORK_TREE")
+    unset_environ = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
     default_arg_rev = "HEAD"
 
     @staticmethod

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -93,6 +93,25 @@ def test_git_work_tree_ignored(tmpdir: pathlib.Path) -> None:
     Git.run_command(["status", repo_dir], extra_environ=env, cwd=repo_dir)
 
 
+def test_git_index_file_ignored(tmpdir: pathlib.Path) -> None:
+    """
+    Test that a GIT_INDEX_FILE environment variable is ignored.
+    """
+    repo_path = tmpdir / "test-repo"
+    repo_path.mkdir()
+    repo_dir = str(repo_path)
+
+    Git.run_command(["init", repo_dir], cwd=repo_dir)
+    (repo_path / "tracked.txt").write_text("tracked\n")
+    Git.run_command(["add", "tracked.txt"], cwd=repo_dir)
+
+    env = {"GIT_INDEX_FILE": "foo"}
+    output = Git.run_command(
+        ["ls-files"], extra_environ=env, cwd=repo_dir, show_stdout=False
+    )
+    assert output.strip() == "tracked.txt"
+
+
 def test_get_remote_url(script: PipTestEnvironment, tmpdir: pathlib.Path) -> None:
     source_path = tmpdir / "source"
     source_path.mkdir()


### PR DESCRIPTION
## What does this PR do?

Fixes #14290.

When pip is invoked from a Git hook, GIT_INDEX_FILE may point to the caller repository's index. Git commands used for a VCS requirement can then update that external index, leaving it with entries whose blobs only existed in pip's temporary clone.

This change removes GIT_INDEX_FILE from the environment of pip's Git subprocesses, alongside GIT_DIR and GIT_WORK_TREE. It adds a regression test and a bugfix news entry.

Tested:
- Reproduced the caller-index corruption before the change.
- Verified the same Git clone scenario leaves git fsck --no-dangling clean after the change.
- Ran python -m compileall for the changed Python files.

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment.
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and AI assistance is disclosed below.

Assisted-by: OpenAI Codex